### PR TITLE
fix: missing delegate soft crash

### DIFF
--- a/android/src/main/java/com/teleport/host/PortalHostViewManager.kt
+++ b/android/src/main/java/com/teleport/host/PortalHostViewManager.kt
@@ -2,7 +2,9 @@ package com.teleport.host
 
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.ViewManagerDelegate
 import com.facebook.react.uimanager.annotations.ReactProp
+import com.facebook.react.viewmanagers.PortalHostViewManagerDelegate
 import com.facebook.react.viewmanagers.PortalHostViewManagerInterface
 import com.facebook.react.views.view.ReactViewGroup
 import com.facebook.react.views.view.ReactViewManager
@@ -10,17 +12,21 @@ import com.facebook.react.views.view.ReactViewManager
 @ReactModule(name = PortalHostViewManager.NAME)
 class PortalHostViewManager :
   ReactViewManager(),
-  PortalHostViewManagerInterface<PortalHostView> {
+  PortalHostViewManagerInterface<ReactViewGroup> {
+  private val delegate = PortalHostViewManagerDelegate(this)
+
   override fun getName(): String = NAME
+
+  override fun getDelegate(): ViewManagerDelegate<ReactViewGroup> = delegate
 
   override fun createViewInstance(context: ThemedReactContext): ReactViewGroup = PortalHostView(context)
 
   @ReactProp(name = "name")
   override fun setName(
-    view: PortalHostView?,
+    view: ReactViewGroup?,
     name: String?,
   ) {
-    view?.setName(name)
+    (view as? PortalHostView)?.setName(name)
   }
 
   companion object {

--- a/android/src/main/java/com/teleport/portal/PortalViewManager.kt
+++ b/android/src/main/java/com/teleport/portal/PortalViewManager.kt
@@ -2,7 +2,9 @@ package com.teleport.portal
 
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.ViewManagerDelegate
 import com.facebook.react.uimanager.annotations.ReactProp
+import com.facebook.react.viewmanagers.PortalViewManagerDelegate
 import com.facebook.react.viewmanagers.PortalViewManagerInterface
 import com.facebook.react.views.view.ReactViewGroup
 import com.facebook.react.views.view.ReactViewManager
@@ -10,14 +12,18 @@ import com.facebook.react.views.view.ReactViewManager
 @ReactModule(name = PortalViewManager.NAME)
 class PortalViewManager :
   ReactViewManager(),
-  PortalViewManagerInterface<PortalView> {
+  PortalViewManagerInterface<ReactViewGroup> {
+  private val delegate = PortalViewManagerDelegate(this)
+
   override fun getName(): String = NAME
+
+  override fun getDelegate(): ViewManagerDelegate<ReactViewGroup> = delegate
 
   override fun createViewInstance(context: ThemedReactContext): ReactViewGroup = PortalView(context)
 
   @ReactProp(name = "name")
   override fun setName(
-    view: PortalView?,
+    view: ReactViewGroup?,
     name: String?,
   ) {
     // implement later if needed
@@ -25,10 +31,10 @@ class PortalViewManager :
 
   @ReactProp(name = "hostName")
   override fun setHostName(
-    view: PortalView?,
+    view: ReactViewGroup?,
     name: String?,
   ) {
-    view?.setHostName(name)
+    (view as? PortalView)?.setHostName(name)
   }
 
   companion object {


### PR DESCRIPTION
## 📜 Description

Restore delegates for its view.

## 💡 Motivation and Context

React may trigger a soft crash if method is not implemented. While this method doesn't crash app completely it's still highly desirable to avoid any kind of exceptions, so let's implement missing methods.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- added `getDelegate` method;

## 🤔 How Has This Been Tested?

Tested manually in example app.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
