### PR TITLE
fix: size diff job

### DIFF
--- a/.github/workflows/size-diff-collect.yml
+++ b/.github/workflows/size-diff-collect.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Pack
-        run: npm pack --json
-
       - name: Calculate size of package (target)
         id: old-size
         run: echo "OLD_SIZE=$(node scripts/size.js)" >> "$GITHUB_OUTPUT"
@@ -39,9 +36,6 @@ jobs:
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-
-      - name: Pack
-        run: npm pack --json
 
       - name: Calculate size of package (current)
         id: new-size

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "typecheck": "tsc",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "clean": "del-cli android/build example/android/build example/android/app/build example/ios/build lib",
-    "prepare": "bob build",
+    "prepare": "bob build > /dev/null 2>&1",
     "release": "release-it --only-version",
     "lint-clang": "find ios/ -iname *.h -o -iname *.m -o -iname *.mm | grep -v -e Pods -e build | xargs clang-format -i -n --Werror"
   },


### PR DESCRIPTION
## 📜 Description

Switch to node v20 to fix size diff job.

## 💡 Motivation and Context

This package requires node v20 to build the package successfully, so we need to switch from node 18 to node 20.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- switch to Node v20;
- remove redundant `Pack` step.

## 🤔 How Has This Been Tested?

Tested in this PR.

## 📸 Screenshots (if appropriate):

<img width="923" height="571" alt="image" src="https://github.com/user-attachments/assets/46a85751-f754-4aea-ae52-82eb1fd1424f" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
