### PR TITLE
ci: use node 20.x for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v4
         with:
-          node-version: "18.x"
+          node-version: "20.19.4"
           registry-url: "https://registry.npmjs.org"
           cache: yarn
       - run: yarn install --frozen-lockfile


### PR DESCRIPTION
## 📜 Description

Bump Node version to 20.x

## 💡 Motivation and Context

With Node 18.x build stage fails.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- use Node 20.x for publishing job

## 🤔 How Has This Been Tested?

<img width="1326" height="284" alt="image" src="https://github.com/user-attachments/assets/4720f158-5ca1-4c51-ac97-d89defb3c83f" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
