### PR TITLE
ci: specify `--access public` for publishing the package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,6 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           cache: yarn
       - run: yarn install --frozen-lockfile
-      - run: npm publish --provenance
+      - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## 📜 Description

Added `--access public` to `publish` command.

## 💡 Motivation and Context

As per npm docs:

<img width="809" height="108" alt="image" src="https://github.com/user-attachments/assets/b01153ce-c50c-4a31-922a-d12a0da174e8" />

And indeed we were getting this error:

<img width="834" height="81" alt="image" src="https://github.com/user-attachments/assets/ffb9659f-aaa4-411a-904a-2d13b1f28e06" />

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- added `--access public` to `publish` command.

## 🤔 How Has This Been Tested?

There is no way to test it without a new release.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
