### PR TITLE
fix: update meta tags for main page

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -36,8 +36,8 @@ export default function Home(): ReactNode {
   const { siteConfig } = useDocusaurusContext();
   return (
     <Layout
-      title={`Hello from ${siteConfig.title}`}
-      description="Description will go into a meta tag in <head />"
+      title={siteConfig.tagline}
+      description="Teleport views across your component tree for seamless transitions and powerful UI patterns"
     >
       <HomepageHeader />
     </Layout>


### PR DESCRIPTION
## 📜 Description

<!-- Describe your changes in detail -->

## 💡 Motivation and Context

At the moment package has an incorrect meta-information for main page (it will not help for google search).

<img width="678" height="130" alt="image" src="https://github.com/user-attachments/assets/bad93d35-455f-465d-bb71-42781ed2f577" />

In this PR I'm changing the title and description of the website..

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Docs

- change `title` and `description` meta-tags.

## 🤔 How Has This Been Tested?

Tested manually via localhost:3000

## 📸 Screenshots (if appropriate):

<img width="1378" height="301" alt="image" src="https://github.com/user-attachments/assets/3785cbb4-b1de-492d-8bde-e000983b1036" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
