### PR TITLE
fix: allow `Portal`/`PortalHost` to have styles

### DIFF
--- a/docs/docs/api/components/portal-host.md
+++ b/docs/docs/api/components/portal-host.md
@@ -20,6 +20,10 @@ keywords:
 
 The name of the portal host. It's used to identify the host by `<Portal />` component.
 
+### `style`
+
+The style of the portal host. Accepts [ViewStyle](https://reactnative.dev/docs/view#style) props.
+
 ## Example
 
 ```tsx

--- a/docs/docs/api/components/portal.md
+++ b/docs/docs/api/components/portal.md
@@ -17,6 +17,10 @@ The name of the portal. It's used to identify the portal in the context of the p
 
 The name of the portal host. It's used to identify the host where the content should be rendered.
 
+### `style`
+
+The style of the portal. Accepts [ViewStyle](https://reactnative.dev/docs/view#style) props.
+
 ### `children`
 
 The content that should be rendered in the portal.

--- a/src/components/Portal.tsx
+++ b/src/components/Portal.tsx
@@ -48,7 +48,7 @@ import type { PortalProps } from "../types";
  * });
  * ```
  */
-const PortalComponent = ({ hostName, name, children }: PortalProps) => {
+const PortalComponent = ({ hostName, name, style, children }: PortalProps) => {
   const { state, dispatch } = usePortalManagerContext();
   const instanceId = useId();
 
@@ -77,7 +77,7 @@ const PortalComponent = ({ hostName, name, children }: PortalProps) => {
   }
 
   return (
-    <PortalView hostName={hostName} name={name}>
+    <PortalView hostName={hostName} name={name} style={style}>
       {children}
     </PortalView>
   );

--- a/src/components/PortalHost.tsx
+++ b/src/components/PortalHost.tsx
@@ -24,8 +24,12 @@ import PortalHost from "../views/PortalHost";
  * }
  * ```
  */
-const PortalHostComponent = ({ name, children }: PortalHostProps) => {
-  return <PortalHost name={name}>{children}</PortalHost>;
+const PortalHostComponent = ({ name, children, style }: PortalHostProps) => {
+  return (
+    <PortalHost name={name} style={style}>
+      {children}
+    </PortalHost>
+  );
 };
 
 export default PortalHostComponent;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,5 @@
+import type { ViewStyle } from "react-native";
+
 export type PortalProviderProps = {
   children: React.ReactNode;
 };
@@ -8,5 +10,6 @@ export type PortalHostProps = {
 export type PortalProps = {
   name?: string;
   hostName?: string;
+  style?: ViewStyle;
   children: React.ReactNode;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,6 +5,7 @@ export type PortalProviderProps = {
 };
 export type PortalHostProps = {
   name: string;
+  style?: ViewStyle;
   children?: React.ReactNode;
 };
 export type PortalProps = {

--- a/src/views/Portal/index.web.tsx
+++ b/src/views/Portal/index.web.tsx
@@ -5,7 +5,7 @@ import { createPortal } from "react-dom";
 import { usePortalRegistryContext } from "../../contexts/PortalRegistry";
 import type { PortalProps } from "../../types";
 
-export default function Portal({ hostName, children }: PortalProps) {
+export default function Portal({ hostName, children, style }: PortalProps) {
   const { getHost } = usePortalRegistryContext();
   const elRef = useRef<HTMLDivElement | null>(null);
   if (!elRef.current) {
@@ -13,6 +13,12 @@ export default function Portal({ hostName, children }: PortalProps) {
   }
 
   const sentinelRef = useRef<HTMLDivElement>(null);
+
+  useLayoutEffect(() => {
+    if (elRef.current && style) {
+      Object.assign(elRef.current.style, style);
+    }
+  }, [style]);
 
   useLayoutEffect(() => {
     const el = elRef.current;
@@ -41,7 +47,7 @@ export default function Portal({ hostName, children }: PortalProps) {
 
   return (
     <>
-      {createPortal(children, elRef.current)}
+      {elRef.current ? createPortal(children, elRef.current) : null}
       {/* Invisible sentinel for local position */}
       <div ref={sentinelRef} style={styles.anchor} />
     </>

--- a/src/views/Portal/index.web.tsx
+++ b/src/views/Portal/index.web.tsx
@@ -47,7 +47,7 @@ export default function Portal({ hostName, children, style }: PortalProps) {
 
   return (
     <>
-      {elRef.current ? createPortal(children, elRef.current) : null}
+      {createPortal(children, elRef.current)}
       {/* Invisible sentinel for local position */}
       <div ref={sentinelRef} style={styles.anchor} />
     </>

--- a/src/views/PortalHost/index.web.tsx
+++ b/src/views/PortalHost/index.web.tsx
@@ -11,7 +11,17 @@ function PortalHost({ name, children }: PortalHostProps) {
     };
   }, [name, setHost]);
 
-  return <div ref={(ref) => setHost(name, ref)}>{children}</div>;
+  return (
+    <div style={styles.anchor} ref={(ref) => setHost(name, ref)}>
+      {children}
+    </div>
+  );
 }
+
+const styles = {
+  anchor: {
+    display: "contents",
+  },
+};
 
 export default memo(PortalHost);


### PR DESCRIPTION
## 📜 Description

Allow to pass `style` for `Portal`/`PortalHost`.

## 💡 Motivation and Context

`@gorhom/portal` simply renders `React.Fragment` so style is managed by child element only. However this library wraps all children in its own `View`/`div` to get a reference to the element (via ref on web, via native component on iOS/Android) and `View`/`div` will break styling of child elements (element will not be stretched to parent dimensions if we pass `flex: 1` etc., because parent may have zero view dimensions).

So in this PR:
- I allow to pass `style` to `Portal` (`PortalView` on iOS/Android);
- in `PortalView` on web we assign style directly to our teleportable element created via `document.createElement()` (because this element acts as a container);
- I allow to pass `style` to `PortalHost` (`PortalHostView` on iOS/Android)
- in `PortalHostView` on web we pass  `display: "contents"` to container `HostView` (otherwise additional `div` will also break styling).

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

-
-

### iOS

-
-

### Android

-
-

## 🤔 How Has This Been Tested?

Tested manually on web example (mobile app still has some issues with styling due to missing updates on `ShadowNode` level).

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
