### PR TITLE
feat: flex styles example

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -13,6 +13,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@gorhom/portal": "^1.0.14",
     "@lottiefiles/dotlottie-react": "^0.15.2",
     "@react-native/new-app-screen": "0.81.0",
     "@react-navigation/elements": "^2.6.4",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,5 +1,6 @@
 import { StyleSheet, View } from "react-native";
 import { PortalHost, PortalProvider } from "react-native-teleport";
+import { PortalProvider as GorhomPortalProvider } from "@gorhom/portal";
 import {
   initialWindowMetrics,
   SafeAreaProvider,
@@ -12,14 +13,19 @@ export default function App() {
   return (
     <SafeAreaProvider initialMetrics={initialWindowMetrics}>
       <GestureHandlerRootView style={styles.container}>
-        <PortalProvider>
-          <NavigationContainer>
-            <RootStack />
-          </NavigationContainer>
-          <View style={StyleSheet.absoluteFillObject} pointerEvents="box-none">
-            <PortalHost name="overlay" />
-          </View>
-        </PortalProvider>
+        <GorhomPortalProvider>
+          <PortalProvider>
+            <NavigationContainer>
+              <RootStack />
+            </NavigationContainer>
+            <View
+              style={StyleSheet.absoluteFillObject}
+              pointerEvents="box-none"
+            >
+              <PortalHost name="overlay" />
+            </View>
+          </PortalProvider>
+        </GorhomPortalProvider>
       </GestureHandlerRootView>
     </SafeAreaProvider>
   );

--- a/example/src/constants/screenNames.ts
+++ b/example/src/constants/screenNames.ts
@@ -5,6 +5,7 @@ export enum ScreenNames {
   DYNAMIC_CHILDREN = "DYNAMIC_CHILDREN",
   INSTANT_ROOT = "INSTANT_ROOT",
   HOOKS = "HOOKS",
+  FLEXIBLE_STYLES = "FLEXIBLE_STYLES",
 }
 
 export enum StackNames {

--- a/example/src/navigation/ExamplesStack/index.tsx
+++ b/example/src/navigation/ExamplesStack/index.tsx
@@ -7,6 +7,7 @@ import RNTouchableExample from "../../screens/RNTouchable";
 import DynamicChildrenExample from "../../screens/DynamicChildren";
 import InstantRoot from "../../screens/InstantRoot";
 import Hook from "../../screens/Hook/Hook";
+import FlexibleStyles from "../../screens/FlexibleStyles";
 
 export type ExamplesStackParamList = {
   [ScreenNames.LOTTIE]: undefined;
@@ -15,6 +16,7 @@ export type ExamplesStackParamList = {
   [ScreenNames.DYNAMIC_CHILDREN]: undefined;
   [ScreenNames.INSTANT_ROOT]: undefined;
   [ScreenNames.HOOKS]: undefined;
+  [ScreenNames.FLEXIBLE_STYLES]: undefined;
 };
 
 const Stack = createNativeStackNavigator<ExamplesStackParamList>();
@@ -37,6 +39,9 @@ const options = {
   },
   [ScreenNames.HOOKS]: {
     title: "Hooks",
+  },
+  [ScreenNames.FLEXIBLE_STYLES]: {
+    title: "Flexible styles",
   },
 };
 
@@ -71,6 +76,11 @@ const ExamplesStack = () => (
       component={Hook}
       name={ScreenNames.HOOKS}
       options={options[ScreenNames.HOOKS]}
+    />
+    <Stack.Screen
+      component={FlexibleStyles}
+      name={ScreenNames.FLEXIBLE_STYLES}
+      options={options[ScreenNames.FLEXIBLE_STYLES]}
     />
   </Stack.Navigator>
 );

--- a/example/src/screens/FlexibleStyles/index.tsx
+++ b/example/src/screens/FlexibleStyles/index.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+import { Button, View } from "react-native";
+import { Portal, PortalHost } from "react-native-teleport";
+import {
+  Portal as GorhomPortal,
+  PortalHost as GorhomPortalHost,
+} from "@gorhom/portal";
+
+export default function FlexibleStyles() {
+  const [destination, setDestination] = useState<string>();
+  const [gorhom, setGorhom] = useState<string>();
+
+  return (
+    <View style={{ flex: 1 }}>
+      <Button title="Overlay" onPress={() => setDestination("overlay")} />
+      <Button title="Back" onPress={() => setDestination(undefined)} />
+      <Button
+        title="Gorhom Overlay"
+        onPress={() => setGorhom("gorhom-overlay")}
+      />
+      <Button title="Gorhom Back" onPress={() => setGorhom(undefined)} />
+      <View style={{ flex: 1, backgroundColor: "red" }} />
+      <View style={{ flex: 1, backgroundColor: "green" }}>
+        <View style={{ width: 50, height: 50 }}>
+          {gorhom && (
+            <GorhomPortal hostName={gorhom}>
+              <View
+                style={{
+                  flex: 1,
+                  width: "100%",
+                  height: "100%",
+                  backgroundColor: "purple",
+                }}
+              />
+            </GorhomPortal>
+          )}
+        </View>
+      </View>
+      <View style={{ flex: 1, backgroundColor: "blue" }}>
+        <View style={{ width: 50, height: 50 }}>
+          <Portal hostName={destination} style={{ flex: 1 }}>
+            <View
+              style={{
+                flex: 1,
+                width: "100%",
+                height: "100%",
+                backgroundColor: "yellow",
+              }}
+              testID="teleport"
+            />
+          </Portal>
+        </View>
+      </View>
+      <View
+        style={{ position: "absolute", top: 0, bottom: 0, left: 0, right: 0 }}
+        pointerEvents="none"
+      >
+        <PortalHost name="overlay" />
+      </View>
+      <View
+        style={{ position: "absolute", top: 0, bottom: 0, left: 0, right: 0 }}
+        pointerEvents="none"
+      >
+        <GorhomPortalHost name="gorhom-overlay" />
+      </View>
+    </View>
+  );
+}

--- a/example/src/screens/Main/constants.ts
+++ b/example/src/screens/Main/constants.ts
@@ -39,4 +39,10 @@ export const examples: Example[] = [
     info: ScreenNames.HOOKS,
     icons: "🎣",
   },
+  {
+    title: "Flexible styles",
+    testID: "flexible_styles",
+    info: ScreenNames.FLEXIBLE_STYLES,
+    icons: "💪",
+  },
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -3270,6 +3270,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@gorhom/portal@npm:^1.0.14":
+  version: 1.0.14
+  resolution: "@gorhom/portal@npm:1.0.14"
+  dependencies:
+    nanoid: ^3.3.1
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 227bb96a2db854ab29bb9da8d4f3823c7f7448358de459709dd1b78522110da564c9a8734c6bc7d7153ed7c99320e0fb5d60b420c2ebb75ecaf2f0d757f410f9
+  languageName: node
+  linkType: hard
+
 "@hapi/hoek@npm:^9.0.0, @hapi/hoek@npm:^9.3.0":
   version: 9.3.0
   resolution: "@hapi/hoek@npm:9.3.0"
@@ -16373,7 +16385,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11":
+"nanoid@npm:^3.3.1, nanoid@npm:^3.3.11":
   version: 3.3.11
   resolution: "nanoid@npm:3.3.11"
   bin:
@@ -18834,6 +18846,7 @@ __metadata:
     "@babel/core": ^7.25.2
     "@babel/preset-env": ^7.25.3
     "@babel/runtime": ^7.25.0
+    "@gorhom/portal": ^1.0.14
     "@lottiefiles/dotlottie-react": ^0.15.2
     "@react-native-community/cli": 20.0.0
     "@react-native-community/cli-platform-android": 20.0.0


### PR DESCRIPTION
## 📜 Description

Added an example when teleported child has `flex: 1` style.

## 💡 Motivation and Context

The original idea is that of having this example is that when we teleport a view it should use parent layout and don't be restricted of its original location. This indeed works on web, but doesn't work on mobile yet. There is an ongoing investigation https://github.com/kirillzyusko/react-native-teleport/issues/24 in terms of what should be changed to make it working. But as a start point I'd love to have an example that will show case the problem and will compare it with proper layout in portals that are based on contexts and web. This PR exactly adds it.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- added example when teleported child has `flex: 1` style.

## 🤔 How Has This Been Tested?

Tested on iOS/Android/web.

## 📸 Screenshots (if appropriate):

<img width="1730" height="906" alt="image" src="https://github.com/user-attachments/assets/bf26d7b6-12c0-494b-abb1-1b6f80e1ec3e" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
