### PR TITLE
fix: do not use hosts with the same names

### DIFF
--- a/example/src/screens/FlexibleStyles/index.tsx
+++ b/example/src/screens/FlexibleStyles/index.tsx
@@ -12,7 +12,7 @@ export default function FlexibleStyles() {
 
   return (
     <View style={{ flex: 1 }}>
-      <Button title="Overlay" onPress={() => setDestination("overlay")} />
+      <Button title="Overlay" onPress={() => setDestination("flex")} />
       <Button title="Back" onPress={() => setDestination(undefined)} />
       <Button
         title="Gorhom Overlay"
@@ -55,7 +55,7 @@ export default function FlexibleStyles() {
         style={{ position: "absolute", top: 0, bottom: 0, left: 0, right: 0 }}
         pointerEvents="none"
       >
-        <PortalHost name="overlay" style={{ flex: 1 }} />
+        <PortalHost name="flex" style={{ flex: 1 }} />
       </View>
       <View
         style={{ position: "absolute", top: 0, bottom: 0, left: 0, right: 0 }}


### PR DESCRIPTION
## 📜 Description

Do not use `PortalHost` with the same names.

## 💡 Motivation and Context

The issue is that `PortalHost` in "Flexible styles" had name "overlay", and we used the same PortalHost name in `App.tsx` level. When you use identical names you override layout etc. of portal hosts so as a result it leads to unpredictable results.

So in this PR I started to use unique names 👀 

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- change portal name from `overlay` to `flex` in `flex` example;

## 🤔 How Has This Been Tested?

Tested manually on iPhone 16 Pro.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/f862f43e-f66c-423c-96dc-c20952720f5f">|<video src="https://github.com/user-attachments/assets/d5b0e92c-4d64-4499-a8c7-14717be980e1">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
