### PR TITLE
fix: race condition in messenger example

### DIFF
--- a/example/src/screens/Messenger/index.tsx
+++ b/example/src/screens/Messenger/index.tsx
@@ -45,6 +45,7 @@ const Message = ({ sender, text }: MessageProps) => {
 
 export default function Messenger() {
   const viewRef = useRef<View>(null);
+  const timeoutId = useRef<number>(undefined);
   const [teleport, setTeleported] = useState(false);
   const [style, setStyle] = useState({ paddingTop: 0 });
   const [blur, setBlur] = useState(false);
@@ -52,13 +53,14 @@ export default function Messenger() {
   const handleClick = () => {
     if (blur) {
       setBlur(false);
-      setTimeout(() => {
+      timeoutId.current = setTimeout(() => {
         // after blur animation finish
         setTeleported(false);
         setStyle({ paddingTop: 0 });
       }, 500);
       return;
     }
+    clearTimeout(timeoutId.current);
     setBlur(true);
     // @ts-expect-error I don't know what's wrong with types here
     viewRef.current?.measureInWindow((_x: number, y: number) => {

--- a/ios/PortalView.mm
+++ b/ios/PortalView.mm
@@ -50,7 +50,6 @@ using namespace facebook::react;
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
 {
-  const auto &oldViewProps = *std::static_pointer_cast<PortalViewProps const>(_props);
   const auto &newViewProps = *std::static_pointer_cast<PortalViewProps const>(props);
 
   std::string newHostStr = newViewProps.hostName;
@@ -58,7 +57,6 @@ using namespace facebook::react;
       newHostStr.empty() ? nil : [NSString stringWithUTF8String:newHostStr.c_str()];
 
   std::string newNameStr = newViewProps.name;
-  NSString *newName = newNameStr.empty() ? nil : [NSString stringWithUTF8String:newNameStr.c_str()];
 
   if (![self.hostName isEqualToString:newHostName]) {
     self.hostName = newHostName;


### PR DESCRIPTION
## 📜 Description

Fixed an issue when lottie animation is not teleported after click.

## 💡 Motivation and Context

We had a race condition: if you click on sticker during fade-out animation, then you can see that blur has been applied but sticker wasn't teleported. Initially I thought that the race condition is somewhere in ObjC code. However turned out that I teleport view back after fixed interval time (I did it for simplicity), so there can be a race condition, when we clicked to teleport, clicked to unteleport (schedule a call after 500ms), clicked again to teleport and after 500ms we unteleport view which leads to this bug.

The fix is quite trivial - we need to unschedule task if we get a new task, so I added ref + clearTimeout for these purposes.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- added `clearTimeout` to avoid race conditions;

### iOS

- remove unused variables to avoid warnings;

## 🤔 How Has This Been Tested?

Tested on iPhone 16 Pro.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/99889030-bbeb-4747-ae64-44436130d276">|<video src="https://github.com/user-attachments/assets/526fa207-c178-4fc7-ad5e-bc673fdf4448">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
