### PR TITLE
fix: touch recursion

### DIFF
--- a/ios/PortalView.mm
+++ b/ios/PortalView.mm
@@ -159,6 +159,12 @@ using namespace facebook::react;
     // of the hit view will return YES from -pointInside:withEvent:). See:
     //  - https://developer.apple.com/library/ios/qa/qa2013/qa1812.html
     for (UIView *subview in [_targetView.subviews reverseObjectEnumerator]) {
+      // Prevent circular hit-testing by checking if we're in the subview's hierarchy
+      if ([self isDescendantOfView:subview]) {
+        // Skip views that contain us to prevent cycles
+        continue;
+      }
+
       CGPoint convertedPoint = [subview convertPoint:point fromView:self];
       hitSubview = [subview hitTest:convertedPoint withEvent:event];
       if (hitSubview != nil) {


### PR DESCRIPTION
## 📜 Description

Fixed a problem with crash after tap on `PortalView` surface.

## 💡 Motivation and Context

The stacktrace is below:

<img width="450" height="1270" alt="image" src="https://github.com/user-attachments/assets/899a3d87-55ee-42c6-9e71-a6b59032aac4" />

It looks like we are trying to find a view that will respond to the touch, but for some reasons after several iterations the source view (i. e. `PortalView`) gets scanned again and it leads to infinite recursion. To fix that I added a condition inside `for`-loop to avoid further responder checks, if underlying view is equal to current view (to avoid recursion).

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### iOS

- added a condition for skipping checking view hierarchy if current view is a descendant subview;

## 🤔 How Has This Been Tested?

Tested in client. No crash after this patch being applied.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
