### PR TITLE
fix: override `pointerEvents` instead of overwriting

### DIFF
--- a/android/src/main/java/com/teleport/host/PortalHostView.kt
+++ b/android/src/main/java/com/teleport/host/PortalHostView.kt
@@ -10,9 +10,7 @@ class PortalHostView(
 ) : ReactViewGroup(context) {
   private var name: String? = null
 
-  init {
-    this.pointerEvents = PointerEvents.BOX_NONE
-  }
+  override var pointerEvents = PointerEvents.BOX_NONE
 
   fun setName(newName: String?) {
     if (name == newName) return


### PR DESCRIPTION
## 📜 Description

Fixed compilation problem on RN 0.79 and lower.

## 💡 Motivation and Context

The current approach has 2 main limitations:
- on RN 0.79 `ReactViewGroup` class was written in Java and field name was `mPointerEvents`, so current codebase can not be compiled on older RN versions;
- during recycling pointer events wil lbe set again to `auto` (and constructor will not be called again, because view is getting re-used);

To solve this problem I decided to override the getter for the variable instead of manually changing it in parent class. This fix wil lfix bopth issues mentioned above.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- override `pointerEvents` instead of ovewriting;

## 🤔 How Has This Been Tested?

Tested manually in client project + verified by e2e tests that functionality is not broken.

## 📸 Screenshots (if appropriate):

<img width="365" height="54" alt="image" src="https://github.com/user-attachments/assets/d2407691-88d2-4c9d-9983-2817a0141684" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
