### PR TITLE
fix: crash on Android

### DIFF
--- a/android/src/main/java/com/teleport/portal/PortalView.kt
+++ b/android/src/main/java/com/teleport/portal/PortalView.kt
@@ -36,10 +36,10 @@ class PortalView(
         }
       } ?: this
 
-    // Add children to new target
     for (i in children.indices) {
       val child = children[i]
-      target.addView(child, if (target == this) i else -1) // Append if to host, preserve index if to self
+      // Append if to host, preserve index if to self
+      target.addView(child, if (target == this) i else -1)
     }
 
     // Track own children if teleported


### PR DESCRIPTION
## 📜 Description

Fixed infinite recursion on Android.

## 💡 Motivation and Context

Everything works well when we have a single `Portal` teleported to `PortalHost`. But when we have let's say 5 Portals mounted in `PortalHost` (under the same name), then `getChildCount` gets crazy, because it scans all 5 Portals from a `PortalHost`. And it happens for all 5 Portals. In reality none of these 5 Portals may have such amount of views and we produce an incorrect recursion/loop and Android just throws an error:

```kt
ava.lang.StackOverflowError: stack size 8176KB
at android.view.View.isTextDirectionInherited(View.java:30288)
at android.view.ViewGroup.resetResolvedTextDirection(ViewGroup.java:7959)
at android.view.ViewGroup.resetResolvedTextDirection(ViewGroup.java:7960)
at android.view.ViewGroup.resetResolvedTextDirection(ViewGroup.java:7960)
at android.view.ViewGroup.resetResolvedTextDirection(ViewGroup.java:7960)
at android.view.ViewGroup.resetResolvedTextDirection(ViewGroup.java:7960)
at android.view.ViewGroup.resetResolvedTextDirection(ViewGroup.java:7960)
at android.view.ViewGroup.resetResolvedTextDirection(ViewGroup.java:7960)
at android.view.ViewGroup.resetResolvedTextDirection(ViewGroup.java:7960)
at android.view.ViewGroup.resetResolvedTextDirection(ViewGroup.java:7960)
at android.view.ViewGroup.resetResolvedTextDirection(ViewGroup.java:7960)
...
  android.view.View.resetRtlProperties(View.java:22362)
  android.view.ViewGroup.addViewInner(ViewGroup.java:5307)
  android.view.ViewGroup.addView(ViewGroup.java:5085)
  android.view.ViewGroup.addView(ViewGroup.java:5025)
  com.facebook.react.views.view.ReactClippingViewManager.addView(ReactClippingViewManager.kt:36)
  com.facebook.react.views.view.ReactClippingViewManager.addView(ReactClippingViewManager.kt:20)
  com.facebook.react.fabric.mounting.SurfaceMountingManager.addViewAt(SurfaceMountingManager.java:407)
  com.facebook.react.fabric.mounting.mountitems.IntBufferBatchMountItem.execute(IntBufferBatchMountItem.kt:111)
  com.facebook.react.fabric.mounting.MountItemDispatcher.executeOrEnqueue(MountItemDispatcher.kt:312)
  com.facebook.react.fabric.mounting.MountItemDispatcher.dispatchMountItems(MountItemDispatcher.kt:221)
  com.facebook.react.fabric.mounting.MountItemDispatcher.tryDispatchMountItems(MountItemDispatcher.kt:88)
  com.facebook.react.fabric.FabricUIManager$DispatchUIFrameCallback.doFrameGuarded(FabricUIManager.java:1484)
  com.facebook.react.uimanager.GuardedFrameCallback.doFrame(GuardedFrameCallback.kt:25)
  com.facebook.react.modules.core.ReactChoreographer.frameCallback$lambda$1(ReactChoreographer.kt:59)
  com.facebook.react.modules.core.ReactChoreographer.$r8$lambda$nSkFhrr5T7rop_XKwzlLov4NLLw(Unknown Source:0)
  com.facebook.react.modules.core.ReactChoreographer$$ExternalSyntheticLambda0.doFrame(D8$$SyntheticClass:0)
  android.view.Choreographer$CallbackRecord.run(Choreographer.java:1404)
  android.view.Choreographer$CallbackRecord.run(Choreographer.java:1415)
  android.view.Choreographer.doCallbacks(Choreographer.java:1015)
  android.view.Choreographer.doFrame(Choreographer.java:941)
  android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:1389)
  android.os.Handler.handleCallback(Handler.java:959)
  android.os.Handler.dispatchMessage(Handler.java:100)
  android.os.Looper.loopOnce(Looper.java:232)
  android.os.Looper.loop(Looper.java:317)
  android.app.ActivityThread.main(ActivityThread.java:8705)
  java.lang.reflect.Method.invoke(Native Method)
  com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:580)
  com.android.internal.os.ZygoteInit.main(ZygoteInit.java:886)
```

Initially I thought to fix it by removing custom implementation of `getChildCount` etc. But in this case it will produce artifacts (backdrop of bottom sheet will not disappear after dismissal, messenger lottie will have incorrect position when teleported etc.)

So the correct solution is to store all children internally and have a reference to it. I. e. we can return a correct amount of children and will not mislead Android OS.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- store all children in `ownChildren` variable;
- return correct amount of children from `getChildCount` (and return correct children by its index);
- added utility functions `extractPhysicalChildren`/`extractTeleportedChildren`/`extractChildren`;
- don't fallback to super logic, if view is teleported, but host not found (add/remove operations);
- clear children if `Portal` was detached from window;

## 🤔 How Has This Been Tested?

Tested in client project. Tested in example project. Verified by e2e tests.

## 📸 Screenshots (if appropriate):

<img width="372" height="801" alt="image" src="https://github.com/user-attachments/assets/b18deea6-7cd2-43c7-bf45-0a43fb1a50e1" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
