### PR TITLE
 Fix: Remove Child-Clearing Logic in `PortalView` (#52)

### DIFF
--- a/android/src/main/java/com/teleport/portal/PortalView.kt
+++ b/android/src/main/java/com/teleport/portal/PortalView.kt
@@ -183,13 +183,6 @@ class PortalView(
       hostName?.let { PortalRegistry.unregisterPendingPortal(it, this) }
       isWaitingForHost = false
     }
-    if (isTeleported()) {
-      val host = PortalRegistry.getHost(hostName)
-      for (child in ownChildren) {
-        host?.removeView(child)
-      }
-      ownChildren.clear()
-    }
   }
   // endregion
 }


### PR DESCRIPTION
## 📜 Description

This PR removes the block inside `onDetachedFromWindow()` that:

- Iterated through `ownChildren`
- Removed them from the host
- Cleared the list

This logic caused portal children to disappear after navigation, as Android lacked a restore mechanism similar to iOS (`contentView` + `onHostAvailable`).  
With the block removed, portal views persist correctly and reattach when the screen regains focus.

## 💡 Motivation and Context

Navigating away from a screen triggers `onDetachedFromWindow()` on Android, which previously cleared all teleported children.  
Since these children were never restored, portals stopped working when returning to earlier screens.

This change fixes:

- Portals not rendering when navigating back  
- Loss of teleported children during lifecycle transitions  
- Behavioral inconsistency between iOS and Android  

The result is a simpler and more predictable lifecycle aligned with the iOS implementation.

## 📢 Changelog

### Android

- Removed child-clearing logic from `PortalView.kt` → `onDetachedFromWindow()`
- Fixed portal content being destroyed during navigation
- Improved parity with iOS portal lifecycle

## 🤔 How Has This Been Tested?

- Navigated between screens using teleported UI (e.g., bottom sheets)
- Verified portals remain functional when returning to previous screens
- Confirmed children attach to the correct host without duplication
- Ensured normal portal behavior remains unchanged

## 📸 Screenshots (if appropriate)



## 📝 Checklist

- [x] CI successfully passed  
- [x] I added new mocks and corresponding unit-tests if library API was changed
- [x] Verified behavior on both iOS and Android
