### PR TITLE
feat: add pointerEvents property to `PortalView` for touch handling

### DIFF
--- a/android/src/main/java/com/teleport/portal/PortalView.kt
+++ b/android/src/main/java/com/teleport/portal/PortalView.kt
@@ -3,6 +3,7 @@ package com.teleport.portal
 import android.content.Context
 import android.view.View
 import android.view.ViewGroup
+import com.facebook.react.uimanager.PointerEvents
 import com.facebook.react.views.view.ReactViewGroup
 import com.teleport.global.PortalRegistry
 import java.util.ArrayList
@@ -13,6 +14,9 @@ class PortalView(
   private var hostName: String? = null
   private var isWaitingForHost = false
   private val ownChildren: MutableList<View> = ArrayList()
+
+  // pass through touches when no child is hit (matches iOS hitTest behavior)
+  override var pointerEvents = PointerEvents.BOX_NONE
 
   fun setHostName(name: String?) {
     val children = extractChildren()


### PR DESCRIPTION
## 📜 Description

This PR adds `pointerEvents = PointerEvents.BOX_NONE` to the Android `PortalView` component. 

## 💡 Motivation and Context

On Android, `PortalView` previously intercepted all touch events even when none of its children required them. This caused underlying UI elements—such as navigation headers, buttons, and screen content—to become non-interactive.

This change:

- Restores parity with iOS  
- Prevents unexpected gesture blocking  
- Ensures portals behave correctly when mounted globally 

## 📢 Changelog

**JS**
- No changes.

**iOS**
- No changes.

**Android**
- Added `pointerEvents = PointerEvents.BOX_NONE` to `PortalView`.

## 🤔 How Has This Been Tested?

Tested on multiple Android devices and emulators.

Verified that:

- Touch events pass through when no portal child is targeted  
- Portaled components still receive touches normally  
- Navigation-based screens remain interactive when navigating back and forth  
- Behaviour now matches iOS  

## 📸 Screenshots (if appropriate):


## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
