### PR TITLE
fix: clean up space for Android e2e tests

### DIFF
--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -78,6 +78,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          # force to remove default tools
+          tool-cache: true
+          # preserve Android
+          android: false
       - name: Download a single artifact
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## 📜 Description

Clean up space on runner before running tests.

## 💡 Motivation and Context

In https://github.com/kirillzyusko/react-native-teleport/pull/54 we started to see this error:

<img width="990" height="328" alt="image" src="https://github.com/user-attachments/assets/bebd8ed8-8f88-4238-9a15-59c88400aa3a" />

This is a known GitHub issue. Runners don't have a lot of free SSD space so sometimes job may fail randomly. To fix this problem I'm adding `jlumbroso/free-disk-space` action before running any tests. It should fix the problem 🤞 

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- added `jlumbroso/free-disk-space` before tests execution;

## 🤔 How Has This Been Tested?

Tested manually via this PR.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<img width="990" height="328" alt="image" src="https://github.com/user-attachments/assets/bebd8ed8-8f88-4238-9a15-59c88400aa3a" />|<img width="996" height="416" alt="image" src="https://github.com/user-attachments/assets/af7018e8-9a05-4988-8c4b-bceca1442836" />|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
