### PR TITLE
refactor: move `TeleportViewManager` in `managers` package

### DIFF
--- a/android/src/main/java/com/teleport/host/PortalHostViewManager.kt
+++ b/android/src/main/java/com/teleport/host/PortalHostViewManager.kt
@@ -7,7 +7,7 @@ import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.PortalHostViewManagerDelegate
 import com.facebook.react.viewmanagers.PortalHostViewManagerInterface
 import com.facebook.react.views.view.ReactViewGroup
-import com.teleport.util.TeleportViewManager
+import com.teleport.managers.TeleportViewManager
 
 @ReactModule(name = PortalHostViewManager.NAME)
 class PortalHostViewManager :

--- a/android/src/main/java/com/teleport/managers/TeleportViewManager.kt
+++ b/android/src/main/java/com/teleport/managers/TeleportViewManager.kt
@@ -1,4 +1,4 @@
-package com.teleport.util
+package com.teleport.managers
 
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.views.view.ReactViewGroup

--- a/android/src/main/java/com/teleport/portal/PortalViewManager.kt
+++ b/android/src/main/java/com/teleport/portal/PortalViewManager.kt
@@ -7,7 +7,7 @@ import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.PortalViewManagerDelegate
 import com.facebook.react.viewmanagers.PortalViewManagerInterface
 import com.facebook.react.views.view.ReactViewGroup
-import com.teleport.util.TeleportViewManager
+import com.teleport.managers.TeleportViewManager
 
 @ReactModule(name = PortalViewManager.NAME)
 class PortalViewManager :


### PR DESCRIPTION
## 📜 Description

Move `TeleportViewManager` in `managers` package.

## 💡 Motivation and Context

Follow up for https://github.com/kirillzyusko/react-native-teleport/pull/60

I decided to move `TeleportViewManager` into own `managers` folder. I don't like to have `utils` folder because you may put whatever you want there, so I'm always trying to be very specific.

Theoretically yes, we have views + theirs managers, so potentially other devs may want to put ViewManagers into `managers` folder, but we follow a strategy, where for each component we create "view" + "manager" in separate "view_name" folder.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- create own `managers` package;
- move `TeleportViewManager` into `managers` folder.

## 🤔 How Has This Been Tested?

Tested manually via this PR.

## 📸 Screenshots (if appropriate):

<img width="301" height="360" alt="image" src="https://github.com/user-attachments/assets/0d88fbca-9f27-4d4a-963b-dc5ce05b0e6b" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
