### PR TITLE
fix: publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,6 @@ name: 🌐 Publish Package to npmjs
 on:
   release:
     types: [created]
-  pull_request:
-    paths:
-      - ".github/workflows/publish.yml"
   workflow_dispatch:
 jobs:
   publish:


### PR DESCRIPTION
## 📜 Description

Fixed publishing workflow.

## 💡 Motivation and Context

Recently npmjs restricted usage of classic tokens. As a result all workflows that were dependent on it are failing now.

In this PR I'm migrating to the official way of publishing packages from GH actions.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- don't use access tokens;
- use Node 24.x

## 🤔 How Has This Been Tested?

Tested via this PR.

## 📸 Screenshots (if appropriate):

<img width="485" height="220" alt="image" src="https://github.com/user-attachments/assets/96c7b8a8-13b1-4797-a9a1-aef4da33a2b0" />

<img width="782" height="384" alt="image" src="https://github.com/user-attachments/assets/3f0f8b7a-01a3-4332-80bd-c53910505861" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
