### PR TITLE
fix: host cleanup on unmount

### DIFF
--- a/android/src/main/java/com/teleport/host/PortalHostView.kt
+++ b/android/src/main/java/com/teleport/host/PortalHostView.kt
@@ -17,10 +17,7 @@ class PortalHostView(
     newName?.let { PortalRegistry.registerHost(it, this) }
   }
 
-  // region Lifecycle
-  override fun onDetachedFromWindow() {
-    super.onDetachedFromWindow()
+  fun cleanup() {
     name?.let { PortalRegistry.unregisterHost(it) }
   }
-  // endregion
 }

--- a/android/src/main/java/com/teleport/host/PortalHostViewManager.kt
+++ b/android/src/main/java/com/teleport/host/PortalHostViewManager.kt
@@ -21,6 +21,12 @@ class PortalHostViewManager :
 
   override fun createTeleportView(context: ThemedReactContext): ReactViewGroup = PortalHostView(context)
 
+  override fun onDropViewInstance(view: ReactViewGroup) {
+    super.onDropViewInstance(view)
+
+    (view as? PortalHostView)?.cleanup()
+  }
+
   @ReactProp(name = "name")
   override fun setName(
     view: ReactViewGroup?,


### PR DESCRIPTION
## 📜 Description

Fixed a problem of non-teleportable content when screen becomes invisible and visible again.

## 💡 Motivation and Context

The problem is that when screen becomes invisible, then `onDetachedFromWindow` is called. Prior to these changes we were de-regestering host from registry and when user returned back to the screen we were not adding it back to the registry. In reality I think removing from registry on "blur" is a very aggressive approach and we should remove it only when host gets unmounted.

So in this PR I override a method on manager level and call `cleanup` function additionally that unregister the host from registry.

Closes https://github.com/kirillzyusko/react-native-teleport/issues/65

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- unregister host only on unmount;

## 🤔 How Has This Been Tested?

Tested manually on Pixel 9 Pro (API 35).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/4f1fd073-9144-418c-9564-00402327cf60">|<video src="https://github.com/user-attachments/assets/af814499-b25e-4859-be88-83396f4fbb26">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
