### PR TITLE
fix: iOS e2e tests

### DIFF
--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Install Maestro CLI
         run: |
           brew tap mobile-dev-inc/tap
-          brew install maestro
+          brew install mobile-dev-inc/tap/maestro
       - name: Prepare snapshot engine
         run: cd e2e && npm install
 


### PR DESCRIPTION
## 📜 Description

Fixed failing ios e2e tests on CI.

## 💡 Motivation and Context

Tests were failing because of this:

```sh
/Users/runner/work/_temp/efc5327c-cc88-4f74-a87c-586afbdcb43b.sh: line 4: maestro: command not found
```

Turns out that maestro cli was moved to `mobile-dev-inc/tap/maestro`. So in this PR I updated brew name dependency.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- use meastro cli as `mobile-dev-inc/tap/maestro` brew pacakge.

## 🤔 How Has This Been Tested?

Tested via this PR.

## 📸 Screenshots (if appropriate):

<img width="853" height="532" alt="image" src="https://github.com/user-attachments/assets/2693ebce-db28-4f8e-9d84-23274388c4e7" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
