### PR TITLE
ci: cache `DerivedData`

### DIFF
--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -26,6 +26,8 @@ on:
       - "e2e/**"
       - "src/**"
       - "common/**"
+env:
+  XCODE_VERSION: "16.4"
 
 jobs:
   build-ios:
@@ -34,8 +36,6 @@ jobs:
     defaults:
       run:
         working-directory: example/ios
-    env:
-      XCODE_VERSION: "16.3"
     steps:
       - uses: actions/checkout@v4
 
@@ -114,7 +114,7 @@ jobs:
       cancel-in-progress: true
     strategy:
       matrix:
-        devices: [{ ios: 18, xcode: "16.0", macos: 15 }]
+        devices: [{ ios: 18, macos: 15 }]
     needs: build-ios
     steps:
       - uses: actions/checkout@v4
@@ -125,7 +125,7 @@ jobs:
           path: example/ios/build/Build/Products/Release-iphonesimulator/TeleportExample.app/
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "16.3"
+          xcode-version: ${{ env.XCODE_VERSION }}
       - name: Install Maestro CLI
         run: |
           brew tap mobile-dev-inc/tap


### PR DESCRIPTION
## 📜 Description

Improve stability and performance of build job.

## 💡 Motivation and Context

Initially I just wanted to improve performance by caching `DerivedData`. But then I realized, that job may randomly fail because it will not be able to find any simulator:

<img width="1286" height="293" alt="image" src="https://github.com/user-attachments/assets/8717b070-c4aa-4a54-8f25-cd9175434dfe" />

And I fixed it as well, and then encountered a problem, that iOS 18.4 may be not available on Xcode 16.3:

<img width="1310" height="313" alt="image" src="https://github.com/user-attachments/assets/48855082-d769-4165-86a0-9dbf0c72ae1e" />

So I removed version specifier from a build command to make it a little bit more flexible and started to use latest XCode.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- list all devices to avoid random job failures;
- cache `DerivedData` to improve build time;
- don't specify iOS version for build (so that XCode will select best device on its own);
- use latest version of XCode;

## 🤔 How Has This Been Tested?

Tested via this PR.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<img width="1301" height="42" alt="image" src="https://github.com/user-attachments/assets/d1f94990-0adb-4d2f-9c6f-ffac89295616" />|<img width="1300" height="43" alt="image" src="https://github.com/user-attachments/assets/f0982bbe-5346-4ba9-97be-09df56508851" />|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
