### PR TITLE
feat: add `order` prop

### DIFF
--- a/android/src/main/java/com/teleport/portal/PortalView.kt
+++ b/android/src/main/java/com/teleport/portal/PortalView.kt
@@ -13,6 +13,12 @@ class PortalView(
   private var hostName: String? = null
   private var isWaitingForHost = false
   private val ownChildren: MutableList<View> = ArrayList()
+  var order: Int = 0
+
+  private fun insertChildIntoHost(host: ViewGroup, child: View) {
+    val index = minOf(order, host.childCount)
+    host.addView(child, index)
+  }
 
   fun setHostName(name: String?) {
     val children = extractChildren()
@@ -38,8 +44,11 @@ class PortalView(
 
     for (i in children.indices) {
       val child = children[i]
-      // Append if to host, preserve index if to self
-      target.addView(child, if (target == this) i else -1)
+      if (target == this) {
+        target.addView(child, i)
+      } else {
+        insertChildIntoHost(target, child)
+      }
     }
 
     // Track own children if teleported
@@ -57,7 +66,7 @@ class PortalView(
       val children = extractPhysicalChildren()
 
       for (child in children) {
-        host.addView(child)
+        insertChildIntoHost(host, child)
       }
       ownChildren.addAll(children)
     }
@@ -121,7 +130,7 @@ class PortalView(
   ) {
     if (isTeleported()) {
       val host = PortalRegistry.getHost(hostName)
-      host?.addView(child)
+      host?.let { insertChildIntoHost(it, child) }
       ownChildren.add(index, child)
     } else {
       super.addView(child, index)
@@ -135,7 +144,7 @@ class PortalView(
   ) {
     if (isTeleported()) {
       val host = PortalRegistry.getHost(hostName)
-      host?.addView(child, params)
+      host?.let { insertChildIntoHost(it, child) }
       ownChildren.add(index, child)
     } else {
       super.addView(child, index, params)

--- a/android/src/main/java/com/teleport/portal/PortalViewManager.kt
+++ b/android/src/main/java/com/teleport/portal/PortalViewManager.kt
@@ -37,6 +37,14 @@ class PortalViewManager :
     (view as? PortalView)?.setHostName(name)
   }
 
+  @ReactProp(name = "order", defaultInt = 0)
+  override fun setOrder(
+    view: ReactViewGroup?,
+    order: Int,
+  ) {
+    (view as? PortalView)?.order = order
+  }
+
   companion object {
     const val NAME = "PortalView"
   }

--- a/ios/PortalView.mm
+++ b/ios/PortalView.mm
@@ -24,6 +24,7 @@ using namespace facebook::react;
 @property (nonatomic, strong) NSString *hostName;
 @property (nonatomic, strong) UIView *targetView;
 @property (nonatomic, assign) BOOL isWaitingForHost;
+@property (nonatomic, assign) NSInteger order;
 
 @end
 
@@ -49,14 +50,25 @@ using namespace facebook::react;
   return self;
 }
 
+- (void)insertChild:(UIView *)child intoHost:(UIView *)host
+{
+  NSInteger index = MIN(self.order, (NSInteger)host.subviews.count);
+  [host insertSubview:child atIndex:index];
+}
+
 - (void)moveChildrenToTarget:(UIView *)source target:(UIView *)target
 {
   NSArray<UIView *> *children = [source.subviews copy];
   for (UIView *child in children) {
     [child removeFromSuperview];
   }
+  BOOL toHost = (target != self.contentView);
   for (UIView *child in children) {
-    [target addSubview:child];
+    if (toHost) {
+      [self insertChild:child intoHost:target];
+    } else {
+      [target addSubview:child];
+    }
   }
 }
 
@@ -69,6 +81,8 @@ using namespace facebook::react;
       newHostStr.empty() ? nil : [NSString stringWithUTF8String:newHostStr.c_str()];
 
   std::string newNameStr = newViewProps.name;
+
+  self.order = newViewProps.order;
 
   if (![self.hostName isEqualToString:newHostName]) {
     if (self.isWaitingForHost && self.hostName) {
@@ -108,12 +122,13 @@ using namespace facebook::react;
 - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView
                           index:(NSInteger)index
 {
-  if (self.targetView == self.contentView) {
+  BOOL toHost = (self.targetView != self.contentView);
+  if (!toHost) {
     // when adding to self, preserve the React tree order with the provided index
     [self.targetView insertSubview:childComponentView atIndex:index];
   } else {
-    // when adding to a different container (host), append to the
-    [self.targetView addSubview:childComponentView];
+    // when adding to host, use the order prop to control stacking
+    [self insertChild:childComponentView intoHost:self.targetView];
   }
 }
 
@@ -129,8 +144,13 @@ using namespace facebook::react;
 
   PortalHostView *hostView = [[PortalRegistry sharedInstance] getHostWithName:self.hostName];
   if (hostView) {
-    [self moveChildrenToTarget:self.contentView target:(UIView *)hostView];
-    self.targetView = (UIView *)hostView;
+    UIView *host = (UIView *)hostView;
+    NSArray<UIView *> *children = [self.contentView.subviews copy];
+    for (UIView *child in children) {
+      [child removeFromSuperview];
+      [self insertChild:child intoHost:host];
+    }
+    self.targetView = host;
   }
 }
 

--- a/src/components/Portal.tsx
+++ b/src/components/Portal.tsx
@@ -48,7 +48,13 @@ import type { PortalProps } from "../types";
  * });
  * ```
  */
-const PortalComponent = ({ hostName, name, style, children }: PortalProps) => {
+const PortalComponent = ({
+  hostName,
+  name,
+  style,
+  order,
+  children,
+}: PortalProps) => {
   const { state, dispatch } = usePortalManagerContext();
   const instanceId = useId();
 
@@ -73,11 +79,11 @@ const PortalComponent = ({ hostName, name, style, children }: PortalProps) => {
   }, [dispatch, hostName, name, instanceId]);
 
   if (isRemoved) {
-    return <PortalView hostName={hostName} name={name} />;
+    return <PortalView hostName={hostName} name={name} order={order} />;
   }
 
   return (
-    <PortalView hostName={hostName} name={name} style={style}>
+    <PortalView hostName={hostName} name={name} style={style} order={order}>
       {children}
     </PortalView>
   );

--- a/src/specs/PortalViewNativeComponent.ts
+++ b/src/specs/PortalViewNativeComponent.ts
@@ -1,8 +1,10 @@
+import type { Int32 } from "react-native/Libraries/Types/CodegenTypes";
 import { codegenNativeComponent, type ViewProps } from "react-native";
 
 interface NativeProps extends ViewProps {
   name?: string;
   hostName?: string;
+  order?: Int32;
 }
 
 export default codegenNativeComponent<NativeProps>("PortalView", {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,5 +12,7 @@ export type PortalProps = {
   name?: string;
   hostName?: string;
   style?: ViewStyle;
+  /** Controls insertion order when multiple Portals target the same host. Bigger == inserted later */
+  order?: number;
   children?: React.ReactNode;
 };

--- a/src/views/Portal/index.tsx
+++ b/src/views/Portal/index.tsx
@@ -7,7 +7,12 @@ import type { PortalProps } from "../../types";
 
 const supportsMoveBefore =
   typeof Element !== "undefined" && "moveBefore" in Element.prototype;
-export default function Portal({ hostName, children, style }: PortalProps) {
+export default function Portal({
+  hostName,
+  children,
+  style,
+  order: _order,
+}: PortalProps) {
   const { getHost, registerPendingPortal, unregisterPendingPortal } =
     usePortalRegistryContext();
   const elRef = useRef<HTMLDivElement | null>(null);


### PR DESCRIPTION
## 📜 Description

<!-- Describe your changes in detail -->

## 💡 Motivation and Context

In https://github.com/kirillzyusko/react-native-teleport/pull/84 we changed approach and we always attach new children to the end. This is a correct fix, but when we try to teleport multiple components in the same transaction/frame `react-native` traverse a tree from down to top as a result all inner children are attached before than all outer children. As a result it causes this artifact (text is hidden behind image):

https://github.com/user-attachments/assets/07f48b14-8f6b-4c90-97d5-9ed33decc9bb

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

-
-

### iOS

-
-

### Android

-
-

## 🤔 How Has This Been Tested?

Tested on iPhone 17 Pro (iOS 26.2).

## 📸 Screenshots (if appropriate):

https://github.com/user-attachments/assets/6aacf2ce-ebd1-4edf-8ccf-f09ad575623d

## 📝 Checklist

- [ ] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
