### PR TITLE
fix: align style prop with RN ViewProps

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,16 +1,16 @@
-import type { ViewStyle } from "react-native";
+import type { StyleProp, ViewStyle } from "react-native";
 
 export type PortalProviderProps = {
   children: React.ReactNode;
 };
 export type PortalHostProps = {
   name: string;
-  style?: ViewStyle;
+  style?: StyleProp<ViewStyle>;
   children?: React.ReactNode;
 };
 export type PortalProps = {
   name?: string;
   hostName?: string;
-  style?: ViewStyle;
+  style?: StyleProp<ViewStyle>;
   children?: React.ReactNode;
 };


### PR DESCRIPTION
## 📜 Description

This PR aligns the `style` prop's type of the `Portal` and `PortalHost` components with React Native's `ViewProps`, matching the native spec contract.

## 💡 Motivation and Context

Currently, the `Portal` and `PortalHost` views' `style` prop is set to `ViewStyle`. This allows for styling of course, however makes Typescript complain if we want to do something like:

```
<Portal style={[StyleSheet.absoluteFill, style1, style2]}>
  {children}
</Portal>
```

even though the native spec allows it and will work properly (since it extends `ViewProps`).

Also, as a side-quest, libraries which rely on `react-native-teleport` and wish to add `0.85` compatibility are unable to do it with full type safety, as `StyleSheet.absoluteFill` used to be typed as:

```
export const absoluteFill: RegisteredStyle<AbsoluteFillStyle>;
```

until recently and so doing something like `<Portal style={StyleSheet.absoluteFill}>{...}</Portal>` fails the typecheck as well. This of course works on `>=0.85` but on something like RN `0.81` it does not. 

This alignment should fix that.

## 📢 Changelog

- We migrate the `style` prop of both components to `StyleProp<ViewStyle>` in order for it to match the `ViewProps` interface extension

### JS

- Migrate the `Portal` component's `style` prop from `ViewStyle` to `StyleProp<ViewStyle>`
- Migrate the `PortalHost` component's `style` prop from `ViewStyle` to `StyleProp<ViewStyle>`

### iOS

-
-

### Android

-
-

## 🤔 How Has This Been Tested?

The `test`, `typecheck` and `lint` scripts have been run and are passing.

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [x] CI successfully passed
- [ ] I added new mocks and corresponding unit-tests if library API was changed
