### PR TITLE
feat: add ./jest subpath export for bundler moduleResolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
       "types": "./lib/typescript/src/index.d.ts",
       "default": "./lib/module/index.js"
     },
+    "./jest": "./jest/index.js",
     "./package.json": "./package.json"
   },
   "files": [


### PR DESCRIPTION
Based on the [documentation](https://kirillzyusko.github.io/react-native-teleport/docs/recipes/jest-testing-guide), enables importing the Jest mock via `react-native-teleport/jest`.

## Summary
- Adds `./jest` to the `exports` map in `package.json`, pointing to `./jest/index.js`
- Enables importing the jest mock via `react-native-teleport/jest` when the consumer's tsconfig uses `"moduleResolution": "bundler"` (or `"node16"`/`"nodenext"`), which requires explicit subpath exports