### PR TITLE
fix: children teleportation order

### DIFF
--- a/android/src/main/java/com/teleport/host/PortalHostView.kt
+++ b/android/src/main/java/com/teleport/host/PortalHostView.kt
@@ -1,6 +1,8 @@
 package com.teleport.host
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import com.facebook.react.views.view.ReactViewGroup
 import com.teleport.global.PortalRegistry
 
@@ -8,6 +10,26 @@ class PortalHostView(
   context: Context?,
 ) : ReactViewGroup(context) {
   private var name: String? = null
+  private var isInBatch = false
+  private var batchBaseIndex = 0
+
+  /**
+   * Returns the index at which a portal child should be inserted.
+   *
+   * Within a single Fabric commit all mutations run synchronously on the main
+   * thread.  The first call in a commit records the current child count as
+   * the "base"; subsequent calls in the same commit reuse that base so that
+   * bottom-to-top Fabric ordering is compensated by [addView] at a specific index.
+   * A [Handler.post] resets the flag after the commit finishes.
+   */
+  fun nextInsertionIndexForChildAt(childIndex: Int): Int {
+    if (!isInBatch) {
+      isInBatch = true
+      batchBaseIndex = childCount
+      Handler(Looper.getMainLooper()).post { isInBatch = false }
+    }
+    return minOf(batchBaseIndex + childIndex, childCount)
+  }
 
   fun setName(newName: String?) {
     if (name == newName) return

--- a/android/src/main/java/com/teleport/portal/PortalView.kt
+++ b/android/src/main/java/com/teleport/portal/PortalView.kt
@@ -106,7 +106,10 @@ class PortalView(
    * Finds the host index of the first next sibling (in [ownChildren]) that is
    * already present in the host.  Returns -1 when none is found (caller should append).
    */
-  private fun findNextSiblingHostIndex(host: ViewGroup, ownIndex: Int): Int {
+  private fun findNextSiblingHostIndex(
+    host: ViewGroup,
+    ownIndex: Int,
+  ): Int {
     for (i in (ownIndex + 1) until ownChildren.size) {
       val sibling = ownChildren[i]
       val siblingIndex = host.indexOfChild(sibling)

--- a/android/src/main/java/com/teleport/portal/PortalView.kt
+++ b/android/src/main/java/com/teleport/portal/PortalView.kt
@@ -5,6 +5,7 @@ import android.view.View
 import android.view.ViewGroup
 import com.facebook.react.views.view.ReactViewGroup
 import com.teleport.global.PortalRegistry
+import com.teleport.host.PortalHostView
 import java.util.ArrayList
 
 class PortalView(
@@ -36,15 +37,16 @@ class PortalView(
         }
       } ?: this
 
-    for (i in children.indices) {
-      val child = children[i]
-      // Append if to host, preserve index if to self
-      target.addView(child, if (target == this) i else -1)
-    }
-
-    // Track own children if teleported
-    if (target != this) {
+    if (target is PortalHostView) {
+      for (i in children.indices) {
+        val idx = target.nextInsertionIndexForChildAt(i)
+        target.addView(children[i], idx)
+      }
       ownChildren.addAll(children)
+    } else {
+      for (i in children.indices) {
+        target.addView(children[i], i)
+      }
     }
   }
 
@@ -53,11 +55,11 @@ class PortalView(
 
     val host = PortalRegistry.getHost(hostName)
     if (host != null) {
-      // Gather from self (physical, since waiting)
       val children = extractPhysicalChildren()
 
-      for (child in children) {
-        host.addView(child)
+      for (i in children.indices) {
+        val idx = host.nextInsertionIndexForChildAt(i)
+        host.addView(children[i], idx)
       }
       ownChildren.addAll(children)
     }
@@ -100,6 +102,19 @@ class PortalView(
     return children
   }
 
+  /**
+   * Finds the host index of the first next sibling (in [ownChildren]) that is
+   * already present in the host.  Returns -1 when none is found (caller should append).
+   */
+  private fun findNextSiblingHostIndex(host: ViewGroup, ownIndex: Int): Int {
+    for (i in (ownIndex + 1) until ownChildren.size) {
+      val sibling = ownChildren[i]
+      val siblingIndex = host.indexOfChild(sibling)
+      if (siblingIndex >= 0) return siblingIndex
+    }
+    return -1
+  }
+
   // region Children management
   override fun getChildCount(): Int =
     if (isTeleported()) {
@@ -121,8 +136,15 @@ class PortalView(
   ) {
     if (isTeleported()) {
       val host = PortalRegistry.getHost(hostName)
-      host?.addView(child)
       ownChildren.add(index, child)
+      if (host != null) {
+        val hostIndex = findNextSiblingHostIndex(host, index)
+        if (hostIndex >= 0) {
+          host.addView(child, hostIndex)
+        } else {
+          host.addView(child)
+        }
+      }
     } else {
       super.addView(child, index)
     }
@@ -135,8 +157,15 @@ class PortalView(
   ) {
     if (isTeleported()) {
       val host = PortalRegistry.getHost(hostName)
-      host?.addView(child, params)
       ownChildren.add(index, child)
+      if (host != null) {
+        val hostIndex = findNextSiblingHostIndex(host, index)
+        if (hostIndex >= 0) {
+          host.addView(child, hostIndex)
+        } else {
+          host.addView(child, params)
+        }
+      }
     } else {
       super.addView(child, index, params)
     }

--- a/e2e/flows/bottom-sheet.yml
+++ b/e2e/flows/bottom-sheet.yml
@@ -1,0 +1,29 @@
+appId: teleport.example
+---
+- launchApp
+- repeat:
+    while:
+      notVisible:
+        id: "bottom_sheet"
+    commands:
+      - swipe:
+          start: 50%, 80%
+          end: 50%, 20%
+- tapOn:
+    id: "bottom_sheet"
+- assertNotVisible:
+    text: "Sheet"
+- assertNotVisible:
+    text: "Close"
+- tapOn:
+    id: "open_bottom_sheet"
+- assertVisible:
+    text: "Sheet"
+- assertVisible:
+    text: "Close"
+- tapOn:
+    text: "Close"
+- assertNotVisible:
+    text: "Sheet"
+- assertNotVisible:
+    text: "Close"

--- a/example/src/screens/BottomSheet/index.tsx
+++ b/example/src/screens/BottomSheet/index.tsx
@@ -16,6 +16,7 @@ export default function BottomSheet() {
           <View style={styles.row}>
             <View style={styles.column} />
             <TouchableOpacity
+              testID="open_bottom_sheet"
               onPress={() => setVisible(true)}
               style={styles.button}
             >

--- a/ios/PortalHostView.h
+++ b/ios/PortalHostView.h
@@ -14,6 +14,16 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface PortalHostView : RCTViewComponentView
+
+/// Returns the index at which a portal child should be inserted.
+///
+/// Within a single Fabric commit all mutations run synchronously on the main
+/// thread.  The first call in a commit records the current subview count as
+/// the "base"; subsequent calls in the same commit reuse that base so that
+/// bottom-to-top Fabric ordering is compensated by `insertSubview:atIndex:`.
+/// A `dispatch_async` resets the flag after the commit finishes.
+- (NSInteger)nextInsertionIndexForChildAt:(NSInteger)childIndex;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/ios/PortalHostView.mm
+++ b/ios/PortalHostView.mm
@@ -20,6 +20,8 @@ using namespace facebook::react;
 @interface PortalHostView () <RCTPortalHostViewViewProtocol>
 
 @property (nonatomic, strong) NSString *registeredName;
+@property (nonatomic, assign) BOOL isInBatch;
+@property (nonatomic, assign) NSInteger batchBaseIndex;
 
 @end
 
@@ -60,9 +62,25 @@ using namespace facebook::react;
   [super updateProps:props oldProps:oldProps];
 }
 
+- (NSInteger)nextInsertionIndexForChildAt:(NSInteger)childIndex
+{
+  if (!self.isInBatch) {
+    self.isInBatch = YES;
+    self.batchBaseIndex = (NSInteger)self.subviews.count;
+    __weak PortalHostView *weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      weakSelf.isInBatch = NO;
+    });
+  }
+  return MIN(self.batchBaseIndex + childIndex, (NSInteger)self.subviews.count);
+}
+
 - (void)prepareForRecycle
 {
   [super prepareForRecycle];
+
+  self.isInBatch = NO;
+  self.batchBaseIndex = 0;
 
   // Unregister before recycling so a stale registeredName doesn't cause
   // this view to unregister a DIFFERENT host's entry when it's reused

--- a/ios/PortalView.mm
+++ b/ios/PortalView.mm
@@ -6,6 +6,7 @@
 //
 
 #import "PortalView.h"
+#import "PortalHostView.h"
 #import "PortalRegistry.h"
 
 #import <react/renderer/components/TeleportViewSpec/EventEmitters.h>
@@ -57,8 +58,17 @@ using namespace facebook::react;
   for (UIView *child in children) {
     [child removeFromSuperview];
   }
-  for (UIView *child in children) {
-    [target addSubview:child];
+
+  if ([target isKindOfClass:[PortalHostView class]]) {
+    PortalHostView *host = (PortalHostView *)target;
+    for (NSInteger i = 0; i < (NSInteger)children.count; i++) {
+      NSInteger idx = [host nextInsertionIndexForChildAt:i];
+      [target insertSubview:children[i] atIndex:idx];
+    }
+  } else {
+    for (UIView *child in children) {
+      [target addSubview:child];
+    }
   }
 }
 
@@ -106,17 +116,35 @@ using namespace facebook::react;
   [super updateProps:props oldProps:oldProps];
 }
 
+/// Finds the host index of the first next sibling (in _ownChildren) that is
+/// already present in the host.  Returns -1 when none is found (caller should append).
+- (NSInteger)findNextSiblingHostIndex:(NSInteger)ownIndex
+{
+  for (NSInteger i = ownIndex + 1; i < (NSInteger)_ownChildren.count; i++) {
+    UIView *sibling = _ownChildren[i];
+    NSInteger siblingIdx = [self.targetView.subviews indexOfObject:sibling];
+    if (siblingIdx != NSNotFound) {
+      return (NSInteger)siblingIdx;
+    }
+  }
+  return -1;
+}
+
 - (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView
                           index:(NSInteger)index
 {
   [_ownChildren insertObject:childComponentView atIndex:MIN(index, (NSInteger)_ownChildren.count)];
 
   if (self.targetView == self.contentView) {
-    // when adding to self, preserve the React tree order with the provided index
     [self.targetView insertSubview:childComponentView atIndex:index];
   } else {
-    // when adding to a different container (host), append to the end
-    [self.targetView addSubview:childComponentView];
+    NSInteger ownIndex = [_ownChildren indexOfObject:childComponentView];
+    NSInteger hostIndex = [self findNextSiblingHostIndex:ownIndex];
+    if (hostIndex >= 0) {
+      [self.targetView insertSubview:childComponentView atIndex:hostIndex];
+    } else {
+      [self.targetView addSubview:childComponentView];
+    }
   }
 }
 
@@ -133,8 +161,8 @@ using namespace facebook::react;
 
   PortalHostView *hostView = [[PortalRegistry sharedInstance] getHostWithName:self.hostName];
   if (hostView) {
-    [self moveOwnChildrenToTarget:(UIView *)hostView];
     self.targetView = (UIView *)hostView;
+    [self moveOwnChildrenToTarget:(UIView *)hostView];
   }
 }
 

--- a/ios/PortalView.mm
+++ b/ios/PortalView.mm
@@ -136,6 +136,7 @@ using namespace facebook::react;
   [_ownChildren insertObject:childComponentView atIndex:MIN(index, (NSInteger)_ownChildren.count)];
 
   if (self.targetView == self.contentView) {
+    // when adding to self, preserve the React tree order with the provided index
     [self.targetView insertSubview:childComponentView atIndex:index];
   } else {
     NSInteger ownIndex = [_ownChildren indexOfObject:childComponentView];


### PR DESCRIPTION
## 📜 Description

Fixed an issue with wrong view hierarchy after teleportation.

## 💡 Motivation and Context

This PR fixes a regression introduced in https://github.com/kirillzyusko/react-native-teleport/pull/84 In that PR we started to use "append to the end" approach to fix. It fixing the stacking of Alerts order, but breaks bottom sheet + shared transitions. Why it exactly breaks? Because Fabric render traverse the tree from bottom to up. For example in this layout:

```tsx
<Portal>
  <A />
</Portal>

<Portal>
  <B />
</Portal>
```

The operation order will be `B`-view then `A`-view. With "append to the end" approach the final order will be `[B, A]` which doesn't preserve the tree order.

### 1️⃣ Sort by `id`

First idea that I had in my mind was utilizing `viewTag/id` and then sort elements when inserting them. While it **may** work it will have edge cases, for example in:

```tsx
<Portal>
  {condition && <B />
  <A />
</Portal>
```

If view `B` will be mounted later, then it will have higher `id`, and order will be incorrect again (instead of [B, A] it will be [A, B] because view `B` would have bigger `id`). In reality `id` serves different purposes and shouldn't be use as an identification of element position inside the tree.

### 2️⃣ View traversal before insertion

The other idea was view traversal before inserting nodes. So that we could check common ancestor and get real order of views, but this code has many downsides:
- it's complex (really complex);
- it uses big-O notation `(O(n * m * log(n))`. FOr 2-3 elements it's okay, but if we have 100+ elements we'll see freezes.

### 3️⃣ Use reversed insertion during single commit

The next idea that I had: when insertion happens within one commit reverse the order (reverse from fabric + artificial reverse will produce real order, i. e. `array.reverse().reverse()` will give the same order of elements as in original `array`).

The only thing is that we need to identify "commit phase". There is no built-in solution in that, but I used one thing to detect it. React synchronously mounts elements, so we can add a flag (`isInBatch`) that will be set to `true` when first item inserted and set back to `false` in the next frame. When `isInBatch=true` then we need to make pre-pend (not append).

In general I can see 4 use cases:

#### 1️⃣ Move single item (many Portals) in many transactions (Alert case)

For example in layout:

```tsx
<Portal>
  <A />
</Portal>

<Portal>
  <B />
</Portal>

<Portal>
  <C />
</Portal>
```

If we add sequentially in any order - this order will be preserved. Because we run multiple transactions, newly added item will be inserted in the end, i. e.:

[] -> [B] -> [B, C] -> [B, C, A].

#### 2️⃣ Move multiple items (one Portal) in one commit (Bottom sheet case)

```tsx
<Portal>
  <A />
  <B />
</Portal>
```

Will also work, because:

[] -> [B] -> [A, B] (we already have one item within a transaction, so insert before).

#### 3️⃣ Move multiple items (many Portals) in one transaction (Shared transition case)

```tsx
<Portal>
  <A />
</Portal>

<Portal>
  <B />
</Portal>

<Portal>
  <C />
</Portal>
```

When all 3 hosts will be targeting the same host order will be correct anyway:

[] -> [C] -> [B, C] (we already have one item within a transaction, so insert before) -> [A, B, C] (sine it's ongoing transaction).

Other theoretical cases:

#### 4️⃣ Move multiple items (mixed Portals) in one transaction

```tsx
<Portal>
  <A />
</Portal>

<Portal>
  <B />
  <C />
</Portal>
```

Fabric processes bottom-to-top, so Portal with `[B, C]` moves first:

[] -> [B] -> [B, C]

Then Portal with [A] moves — still same transaction, so insert at `batchBase + 0` = `0`:

[B, C] -> [A, B, C] ✅

Intra-portal order [B, C] is preserved because `moveOwnChildrenToTarget` iterates `_ownChildren` in order, and each child gets an incrementing `childIndex` (`batchBase + 0`, `batchBase + 1`, ...).

Closes https://github.com/kirillzyusko/react-native-teleport/issues/114

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### E2E

- cover bottom sheet with e2e tests to avoid regressions in the future;

### iOS

- add `nextInsertionIndexForChildAt` to `PortalHostView`;
- add `findNextSiblingHostIndex` to `PortalView`;

### Android

- add `nextInsertionIndexForChildAt` to `PortalHostView`;
- add `findNextSiblingHostIndex` to `PortalView`;

## 🤔 How Has This Been Tested?

Tested in example app (iPhone 17 Pro, Pixel 9 API 35).

## 📸 Screenshots (if appropriate):

|Bottom Sheet|Alert stacking|Shared transitions (WIP)|
|--------------|--------------|------------------------|
|<video src="https://github.com/user-attachments/assets/b08bc61e-2532-4fe8-b2c6-d759e51ae84d">|<video src="https://github.com/user-attachments/assets/ec87e107-7379-40f1-82d4-564f274797e4">|<video src="https://github.com/user-attachments/assets/e6cb57b7-58a5-4947-9269-dd971b58ae89">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
