### PR TITLE
fix(android): three Fabric reparent crashes in Portal/PortalHost lifecycle

### DIFF
--- a/android/src/main/java/com/teleport/global/PortalRegistry.kt
+++ b/android/src/main/java/com/teleport/global/PortalRegistry.kt
@@ -20,7 +20,14 @@ object PortalRegistry {
         val portalRef = iterator.next()
         portalRef.get()?.onHostAvailable() ?: iterator.remove()
       }
-      pendingPortals.remove(name)
+      // Intentionally do NOT remove the pending list here. Portals stay
+      // subscribed to this hostname so they can re-bind when the host is
+      // re-mounted (e.g. NativeStack pop unmounted the screen hosting
+      // <PortalHost> and a subsequent push mounts a fresh one). The
+      // WeakReference cleanup in the iterator above prunes dead portals,
+      // so leaving the list populated does not leak. Portals also
+      // unsubscribe explicitly when their hostName changes — see
+      // PortalView.setHostName.
     }
   }
 

--- a/android/src/main/java/com/teleport/host/PortalHostView.kt
+++ b/android/src/main/java/com/teleport/host/PortalHostView.kt
@@ -3,6 +3,8 @@ package com.teleport.host
 import android.content.Context
 import android.os.Handler
 import android.os.Looper
+import android.view.View
+import android.view.ViewGroup
 import com.facebook.react.views.view.ReactViewGroup
 import com.teleport.global.PortalRegistry
 
@@ -41,5 +43,33 @@ class PortalHostView(
 
   fun cleanup(viewId: Int) {
     name?.let { PortalRegistry.unregisterHost(it, viewId) }
+  }
+
+  /**
+   * Adopt a child whose mParent reference is stuck pointing at a previous
+   * (now-dropped) host. ViewGroup.addView refuses with IllegalStateException
+   * ("child already has a parent") when child.getParent() != null, but the
+   * protected ViewGroup.addViewInLayout sets `child.mParent = null` from
+   * inside the framework before adding. That works regardless of how the
+   * field is named in the running Android version (Android 16 renamed/
+   * restricted it such that external reflection by literal name throws
+   * NoSuchFieldException) and is the escape hatch for re-bind paths where
+   * the previous host's standard removeView did not clear the child's
+   * parent — which is the common case once Fabric has put the host into
+   * the drop pipeline.
+   *
+   * The previous host's mChildren array may briefly still reference the
+   * child until that host is GC'd, but it has been removed from the window
+   * and is not drawing — so the inconsistency is harmless.
+   */
+  internal fun forceAdoptStuckView(child: View, index: Int) {
+    val params = child.layoutParams ?: ViewGroup.LayoutParams(
+      ViewGroup.LayoutParams.MATCH_PARENT,
+      ViewGroup.LayoutParams.MATCH_PARENT
+    )
+    val safeIndex = minOf(index, childCount)
+    addViewInLayout(child, safeIndex, params, false)
+    requestLayout()
+    invalidate()
   }
 }

--- a/android/src/main/java/com/teleport/host/PortalHostView.kt
+++ b/android/src/main/java/com/teleport/host/PortalHostView.kt
@@ -62,11 +62,15 @@ class PortalHostView(
    * child until that host is GC'd, but it has been removed from the window
    * and is not drawing — so the inconsistency is harmless.
    */
-  internal fun forceAdoptStuckView(child: View, index: Int) {
-    val params = child.layoutParams ?: ViewGroup.LayoutParams(
-      ViewGroup.LayoutParams.MATCH_PARENT,
-      ViewGroup.LayoutParams.MATCH_PARENT
-    )
+  internal fun forceAdoptStuckView(
+    child: View,
+    index: Int,
+  ) {
+    val params =
+      child.layoutParams ?: ViewGroup.LayoutParams(
+        ViewGroup.LayoutParams.MATCH_PARENT,
+        ViewGroup.LayoutParams.MATCH_PARENT,
+      )
     val safeIndex = minOf(index, childCount)
     addViewInLayout(child, safeIndex, params, false)
     requestLayout()

--- a/android/src/main/java/com/teleport/portal/PortalView.kt
+++ b/android/src/main/java/com/teleport/portal/PortalView.kt
@@ -68,14 +68,23 @@ class PortalView(
   private fun isTeleported(): Boolean = hostName != null && PortalRegistry.getHost(hostName) != null
 
   private fun extractPhysicalChildren(): List<View> {
-    val children = mutableListOf<View>()
+    // Gather first, then remove via super.removeView(child). Calling
+    // super.removeViewAt(i) here would dispatch ViewGroup.removeViewAt's
+    // internal getChildAt(index) virtually back through PortalView's
+    // override — which can return null mid-onHostAvailable (isTeleported()
+    // flips true once the host registers, but ownChildren is not populated
+    // until after this method returns), and that null reaches
+    // removeViewInternal as the `view` arg, NPEing on view.unFocus(null).
+    // super.removeView(View) takes a different path that uses indexOfChild
+    // (direct mChildren[] walk) and never re-fetches the view by index.
     val count = super.getChildCount()
-    for (i in count - 1 downTo 0) {
-      val child = super.getChildAt(i) ?: continue
-      children.add(0, child)
-      super.removeViewAt(i)
+    val children = ArrayList<View>(count)
+    for (i in 0 until count) {
+      super.getChildAt(i)?.let { children.add(it) }
     }
-
+    for (child in children) {
+      super.removeView(child)
+    }
     return children
   }
 

--- a/android/src/main/java/com/teleport/portal/PortalView.kt
+++ b/android/src/main/java/com/teleport/portal/PortalView.kt
@@ -18,10 +18,13 @@ class PortalView(
   fun setHostName(name: String?) {
     val children = extractChildren()
 
-    if (isWaitingForHost) {
-      hostName?.let { PortalRegistry.unregisterPendingPortal(it, this) }
-      isWaitingForHost = false
-    }
+    // Always unsubscribe from the old hostname's pending list. The previous
+    // `if (isWaitingForHost)` guard relied on portals being removed from
+    // pendingPortals after the first onHostAvailable; with PortalRegistry
+    // now keeping portals subscribed across host-mount cycles, that guard
+    // misses and leaves stale subscriptions when hostName changes.
+    hostName?.let { PortalRegistry.unregisterPendingPortal(it, this) }
+    isWaitingForHost = false
 
     hostName = name
 
@@ -53,15 +56,31 @@ class PortalView(
   internal fun onHostAvailable() {
     isWaitingForHost = false
 
-    val host = PortalRegistry.getHost(hostName)
-    if (host != null) {
-      val children = extractPhysicalChildren()
+    val host = PortalRegistry.getHost(hostName) ?: return
 
+    if (super.getChildCount() > 0) {
+      // First-time binding: children are still physically inside PortalView.
+      val children = extractPhysicalChildren()
       for (i in children.indices) {
         val idx = host.nextInsertionIndexForChildAt(i)
         host.addView(children[i], idx)
       }
       ownChildren.addAll(children)
+    } else if (ownChildren.isNotEmpty()) {
+      // Re-binding after a previous host was destroyed (e.g. NativeStack
+      // pop unmounted the screen and a subsequent push remounts a fresh
+      // <PortalHost> with the same name). ownChildren references views
+      // that are still parented to the previous (now-orphaned) host.
+      // Standard parent.removeView is a no-op on a Fabric-dropped host
+      // and View.mParent reflection by literal name throws
+      // NoSuchFieldException on Android 16, so use forceAdoptStuckView
+      // (which calls the protected ViewGroup.addViewInLayout — that
+      // clears mParent from inside the framework before adding).
+      val children = ownChildren.toList()
+      for (i in children.indices) {
+        val idx = host.nextInsertionIndexForChildAt(i)
+        host.forceAdoptStuckView(children[i], idx)
+      }
     }
   }
 


### PR DESCRIPTION
> _Disclosure: written by Claude Opus 4.7 (Anthropic). Tested in production by me on Galaxy S24 / Android 16 / 1.1.4 across many nav cycles._

Three independent Android-only bugs in the `Portal` ↔ `PortalHost` reparent path on Fabric - only seen in production. One commit per bug, ordered for clean bisection. iOS unaffected for (1) and (3); see iOS section for a suspected iOS analog of (2).

### 1. NPE in `PortalView.extractPhysicalChildren`

`super.removeViewAt(i)` runs `ViewGroup.removeViewAt`, whose inner `getChildAt(index)` is virtual on `this` and dispatches to `PortalView`'s override. By then the host is registered (`isTeleported() == true`) but `ownChildren` is still empty, so the override returns `null` → `removeViewInternal(view = null)` → NPE on `view.unFocus(null)`.

**Fix:** gather, then `super.removeView(child)` (uses `indexOfChild`, no index re-lookup).

Production crash captured on Galaxy S24 / Android 16:

```
java.lang.NullPointerException: Attempt to invoke virtual method 'void android.view.View.unFocus(android.view.View)' on a null object reference
	at android.view.ViewGroup.removeViewInternal(ViewGroup.java:5864)
	at android.view.ViewGroup.removeViewAt(ViewGroup.java:5827)
	at com.teleport.portal.a.w(SourceFile:26)            ← extractPhysicalChildren
	at com.teleport.portal.a.z(SourceFile:14)            ← setHostName
	at q9.b.c(SourceFile:55)
	at com.teleport.host.a.setName(SourceFile:29)        ← PortalHostView.setName
	at com.teleport.host.PortalHostViewManager.setName(SourceFile:2)
	at com.facebook.react.uimanager.ViewManager.updateProperties(SourceFile:35)
	at com.facebook.react.uimanager.ViewManager.createViewInstance(SourceFile:7)
	at com.facebook.react.fabric.mounting.SurfaceMountingManager.createViewUnsafe(SourceFile:68)
	at com.facebook.react.fabric.mounting.SurfaceMountingManager.preallocateView(SourceFile:25)
	at com.facebook.react.fabric.mounting.mountitems.PreAllocateViewMountItem.execute(SourceFile:54)
	...

Build: samsung/e1quew/e1q:16/BP2A.250605.031.A3 (Galaxy S24, Android 16)
```

### 2. Teleported content lost on second `<PortalHost>` mount cycle

`registerHost` drops `pendingPortals[name]` after first notification, so when the host is unmounted and a same-named one mounts later, `onHostAvailable` never fires on the existing portal. Children stay orphaned in the previous host.

**Fix:** keep portals subscribed across host cycles (`WeakReference` already prunes dead ones); `setHostName` unsubscribes unconditionally on rename; `onHostAvailable` distinguishes first-bind vs re-bind.

### 3. `IllegalStateException` ("child already has a parent") on re-bind

The orphaned child's `mParent` still points at the dying old host. `parent.removeView` is a no-op on a Fabric-dropped host, and `View.mParent` reflection fails on Android 16 (`NoSuchFieldException` — renamed/restricted).

**Fix:** new `PortalHostView.forceAdoptStuckView(child, index)` wraps the protected `ViewGroup.addViewInLayout`, which sets `child.mParent = null` from inside the framework before adding (verified against AOSP `main`) — bypasses both the parent check and the reflection restriction.

### Repro

```jsx
<PortalProvider>
  <Portal hostName="x"><View style={...} /></Portal>
  {hostMounted && <PortalHost name="x" />}
</PortalProvider>
```

Add a NativeStack pop/push that remounts the host to exercise (2) and (3).

### iOS

**Suspected iOS analog of bug 2** — not fixed here but worth flagging: `ios/PortalRegistry.mm` line 58 has the same `[self.pendingPortals removeObjectForKey:name]` after first notification. A `<PortalHost>` unmount/remount cycle on iOS likely produces the same silent-failure UX (second host renders empty) — wouldn't crash since UIKit is more forgiving, but the teleported content wouldn't reappear. I haven't reproduced it on iOS; flagging in case it matches reports you've seen.

### Note

A deeper alternative for (2) — populate `ownChildren` in `addView` regardless of teleport state, mirroring iOS — would also eliminate (1)'s trampoline. Larger change to invariants.


----

Claude Code Session ID `6b76118d-edb3-4caa-b168-b1e73dfd6a7a`
