### PR TITLE
fix(android) [1/3]: NPE in PortalView.extractPhysicalChildren during reparent

### DIFF
--- a/android/src/main/java/com/teleport/portal/PortalView.kt
+++ b/android/src/main/java/com/teleport/portal/PortalView.kt
@@ -68,14 +68,23 @@ class PortalView(
   private fun isTeleported(): Boolean = hostName != null && PortalRegistry.getHost(hostName) != null
 
   private fun extractPhysicalChildren(): List<View> {
-    val children = mutableListOf<View>()
+    // Gather first, then remove via super.removeView(child). Calling
+    // super.removeViewAt(i) here would dispatch ViewGroup.removeViewAt's
+    // internal getChildAt(index) virtually back through PortalView's
+    // override — which can return null mid-onHostAvailable (isTeleported()
+    // flips true once the host registers, but ownChildren is not populated
+    // until after this method returns), and that null reaches
+    // removeViewInternal as the `view` arg, NPEing on view.unFocus(null).
+    // super.removeView(View) takes a different path that uses indexOfChild
+    // (direct mChildren[] walk) and never re-fetches the view by index.
     val count = super.getChildCount()
-    for (i in count - 1 downTo 0) {
-      val child = super.getChildAt(i) ?: continue
-      children.add(0, child)
-      super.removeViewAt(i)
+    val children = ArrayList<View>(count)
+    for (i in 0 until count) {
+      super.getChildAt(i)?.let { children.add(it) }
     }
-
+    for (child in children) {
+      super.removeView(child)
+    }
     return children
   }
 


### PR DESCRIPTION
> _Disclosure: written by Claude Opus 4.7 (Anthropic). Tested in production by me on Galaxy S24 / Android 16 / 1.1.4._

Splits #117 per your request — one PR per bug. **This is 1 of 3.**

### Bug

`PortalView.extractPhysicalChildren` calls `super.removeViewAt(i)`. `ViewGroup.removeViewAt` then runs `getChildAt(index)` virtually on `this`, which dispatches to `PortalView`'s override. By that point the host is registered (so `isTeleported() == true`) but `ownChildren` is still empty (it gets populated *after* `extractPhysicalChildren` returns). The override returns `null`, `removeViewInternal` is invoked with `view = null`, and the focus-clear branch NPEs on `view.unFocus(null)`.

### Production crash

Captured on Galaxy S24 / Android 16 (Samsung One UI 8):

```
java.lang.NullPointerException: Attempt to invoke virtual method 'void android.view.View.unFocus(android.view.View)' on a null object reference
	at android.view.ViewGroup.removeViewInternal(ViewGroup.java:5864)
	at android.view.ViewGroup.removeViewAt(ViewGroup.java:5827)
	at com.teleport.portal.a.w(SourceFile:26)            ← extractPhysicalChildren
	at com.teleport.portal.a.z(SourceFile:14)            ← setHostName
	at q9.b.c(SourceFile:55)
	at com.teleport.host.a.setName(SourceFile:29)        ← PortalHostView.setName
	at com.teleport.host.PortalHostViewManager.setName(SourceFile:2)
	at com.facebook.react.uimanager.ViewManager.updateProperties(SourceFile:35)
	at com.facebook.react.uimanager.ViewManager.createViewInstance(SourceFile:7)
	at com.facebook.react.fabric.mounting.SurfaceMountingManager.createViewUnsafe(SourceFile:68)
	at com.facebook.react.fabric.mounting.SurfaceMountingManager.preallocateView(SourceFile:25)
	at com.facebook.react.fabric.mounting.mountitems.PreAllocateViewMountItem.execute(SourceFile:54)
	...

Build: samsung/e1quew/e1q:16/BP2A.250605.031.A3
```

### Fix

Gather children first, then remove each via `super.removeView(child)` — that path uses `indexOfChild` on `mChildren[]` directly and hands the captured view to `removeViewInternal`. No index re-lookup, no trampoline.

### iOS

Unaffected — the iOS reparent path takes a different shape and doesn't have this virtual-dispatch trampoline.

### Companion PRs

- 2/3: keep portals subscribed across `<PortalHost>` remount cycles
- 3/3: rebind teleported content via `forceAdoptStuckView`

----

Claude Code Session ID `6b76118d-edb3-4caa-b168-b1e73dfd6a7a`
