### PR TITLE
fix(android) [2/3]: keep portals subscribed across PortalHost remount

### DIFF
--- a/android/src/main/java/com/teleport/global/PortalRegistry.kt
+++ b/android/src/main/java/com/teleport/global/PortalRegistry.kt
@@ -20,7 +20,14 @@ object PortalRegistry {
         val portalRef = iterator.next()
         portalRef.get()?.onHostAvailable() ?: iterator.remove()
       }
-      pendingPortals.remove(name)
+      // Intentionally do NOT remove the pending list here. Portals stay
+      // subscribed to this hostname so they can re-bind when the host is
+      // re-mounted (e.g. NativeStack pop unmounted the screen hosting
+      // <PortalHost> and a subsequent push mounts a fresh one). The
+      // WeakReference cleanup in the iterator above prunes dead portals,
+      // so leaving the list populated does not leak. Portals also
+      // unsubscribe explicitly when their hostName changes — see
+      // PortalView.setHostName.
     }
   }
 

--- a/android/src/main/java/com/teleport/portal/PortalView.kt
+++ b/android/src/main/java/com/teleport/portal/PortalView.kt
@@ -18,10 +18,13 @@ class PortalView(
   fun setHostName(name: String?) {
     val children = extractChildren()
 
-    if (isWaitingForHost) {
-      hostName?.let { PortalRegistry.unregisterPendingPortal(it, this) }
-      isWaitingForHost = false
-    }
+    // Always unsubscribe from the old hostname's pending list. The previous
+    // `if (isWaitingForHost)` guard relied on portals being removed from
+    // pendingPortals after the first onHostAvailable; with PortalRegistry
+    // now keeping portals subscribed across host-mount cycles, that guard
+    // misses and leaves stale subscriptions when hostName changes.
+    hostName?.let { PortalRegistry.unregisterPendingPortal(it, this) }
+    isWaitingForHost = false
 
     hostName = name
 


### PR DESCRIPTION
> _Disclosure: written by Claude Opus 4.7 (Anthropic). Tested in production by me on Galaxy S24 / Android 16 / 1.1.4._

Splits #117 per your request — one PR per bug. **This is 2 of 3.**

### Bug

When `<PortalHost name="x">` is unmounted (e.g. NativeStack pops the screen containing it) and a same-named host is mounted later, the new host renders empty: `PortalRegistry.registerHost` drops `pendingPortals[name]` after the first notification, so the existing portal is no longer subscribed and never receives `onHostAvailable` for the new host. Children stay orphaned in the previous host.

This was a silent failure (no crash, no log) — diagnosed via `adb logcat` traces over multiple rebuilds rather than a single stack capture.

### Repro

```jsx
function App() {
  const [hostMounted, setHostMounted] = useState(true);
  return (
    <PortalProvider>
      <Portal hostName="x"><Text>teleported</Text></Portal>
      {hostMounted && <PortalHost name="x" />}
      <Button onPress={() => setHostMounted((v) => !v)} title="toggle host" />
    </PortalProvider>
  );
}
```

Toggle the host off then back on → second mount of `<PortalHost>` renders empty.

(In our production app this manifests as the editor blank on the second navigation to a screen that hosts `<PortalHost>`, where NativeStack pops the screen on the first nav-away and pushes a fresh one on return.)

### Fix

Two coordinated changes:

1. **`PortalRegistry.registerHost`**: keep portals subscribed across host-mount cycles. The `WeakReference` cleanup in the existing iterator already prunes dead portals, so the list does not leak.
2. **`PortalView.setHostName`**: unconditionally unsubscribe from the old hostname's pending list. The previous `if (isWaitingForHost)` guard relied on portals being removed from `pendingPortals` after first bind; with (1) keeping them subscribed, that guard misses.

### Caveat — companion PR 3/3

This PR alone preserves subscriptions and routes the second-mount notification correctly, but the existing `onHostAvailable` first-bind path is a no-op when `ownChildren` are already attached to the previous host. The actual move-children-to-new-host logic comes from the companion 3/3 PR (rebind via `forceAdoptStuckView`). Landing this fix on its own is still safe — eliminates the silent-subscription leak and lays the groundwork.

### iOS

Suspected analog at `ios/PortalRegistry.mm:58` — same `[self.pendingPortals removeObjectForKey:name]` after first notification. Wouldn't crash on iOS (UIKit forgives) but content wouldn't reappear on the second host mount. I haven't reproduced it on iOS — flagging in case it matches reports you've seen.

### Companion PRs

- 1/3: NPE in `extractPhysicalChildren` during reparent
- 3/3: rebind teleported content via `forceAdoptStuckView` (depends on this PR landing first)

----

Claude Code Session ID `6b76118d-edb3-4caa-b168-b1e73dfd6a7a`
