### PR TITLE
fix(android) [3/3]: rebind teleported content via forceAdoptStuckView

### DIFF
--- a/android/src/main/java/com/teleport/host/PortalHostView.kt
+++ b/android/src/main/java/com/teleport/host/PortalHostView.kt
@@ -3,6 +3,8 @@ package com.teleport.host
 import android.content.Context
 import android.os.Handler
 import android.os.Looper
+import android.view.View
+import android.view.ViewGroup
 import com.facebook.react.views.view.ReactViewGroup
 import com.teleport.global.PortalRegistry
 
@@ -41,5 +43,37 @@ class PortalHostView(
 
   fun cleanup(viewId: Int) {
     name?.let { PortalRegistry.unregisterHost(it, viewId) }
+  }
+
+  /**
+   * Adopt a child whose mParent reference is stuck pointing at a previous
+   * (now-dropped) host. ViewGroup.addView refuses with IllegalStateException
+   * ("child already has a parent") when child.getParent() != null, but the
+   * protected ViewGroup.addViewInLayout sets `child.mParent = null` from
+   * inside the framework before adding. That works regardless of how the
+   * field is named in the running Android version (Android 16 renamed/
+   * restricted it such that external reflection by literal name throws
+   * NoSuchFieldException) and is the escape hatch for re-bind paths where
+   * the previous host's standard removeView did not clear the child's
+   * parent — which is the common case once Fabric has put the host into
+   * the drop pipeline.
+   *
+   * The previous host's mChildren array may briefly still reference the
+   * child until that host is GC'd, but it has been removed from the window
+   * and is not drawing — so the inconsistency is harmless.
+   */
+  internal fun forceAdoptStuckView(
+    child: View,
+    index: Int,
+  ) {
+    val params =
+      child.layoutParams ?: ViewGroup.LayoutParams(
+        ViewGroup.LayoutParams.MATCH_PARENT,
+        ViewGroup.LayoutParams.MATCH_PARENT,
+      )
+    val safeIndex = minOf(index, childCount)
+    addViewInLayout(child, safeIndex, params, false)
+    requestLayout()
+    invalidate()
   }
 }

--- a/android/src/main/java/com/teleport/portal/PortalView.kt
+++ b/android/src/main/java/com/teleport/portal/PortalView.kt
@@ -53,15 +53,31 @@ class PortalView(
   internal fun onHostAvailable() {
     isWaitingForHost = false
 
-    val host = PortalRegistry.getHost(hostName)
-    if (host != null) {
-      val children = extractPhysicalChildren()
+    val host = PortalRegistry.getHost(hostName) ?: return
 
+    if (super.getChildCount() > 0) {
+      // First-time binding: children are still physically inside PortalView.
+      val children = extractPhysicalChildren()
       for (i in children.indices) {
         val idx = host.nextInsertionIndexForChildAt(i)
         host.addView(children[i], idx)
       }
       ownChildren.addAll(children)
+    } else if (ownChildren.isNotEmpty()) {
+      // Re-binding after a previous host was destroyed (e.g. NativeStack
+      // pop unmounted the screen and a subsequent push remounts a fresh
+      // <PortalHost> with the same name). ownChildren references views
+      // that are still parented to the previous (now-orphaned) host.
+      // Standard parent.removeView is a no-op on a Fabric-dropped host
+      // and View.mParent reflection by literal name throws
+      // NoSuchFieldException on Android 16, so use forceAdoptStuckView
+      // (which calls the protected ViewGroup.addViewInLayout — that
+      // clears mParent from inside the framework before adding).
+      val children = ownChildren.toList()
+      for (i in children.indices) {
+        val idx = host.nextInsertionIndexForChildAt(i)
+        host.forceAdoptStuckView(children[i], idx)
+      }
     }
   }
 


### PR DESCRIPTION
> _Disclosure: written by Claude Opus 4.7 (Anthropic). Tested in production by me on Galaxy S24 / Android 16 / 1.1.4._

Splits #117 per your request — one PR per bug. **This is 3 of 3.** Builds on the subscription fix in companion PR 2/3 — the rebind branch is unreachable until that lands.

### Bug

With companion PR 2/3 in place, the second `<PortalHost>` mount cycle now fires `onHostAvailable` (subscription preserved), but doing the natural thing — calling `host.addView(child)` from a re-bind branch — crashes on Android 16:

```
java.lang.IllegalStateException: The specified child already has a parent. You must call removeView() on the child's parent first.
	at android.view.ViewGroup.addViewInner(ViewGroup.java:5539)
	at android.view.ViewGroup.addView(ViewGroup.java:5358)
	at android.view.ViewGroup.addView(ViewGroup.java:5298)
	at com.teleport.portal.a.A(SourceFile:124)           ← onHostAvailable re-bind
	at q9.b.c(SourceFile:55)
	at com.teleport.host.b.setName(SourceFile:29)        ← PortalHostView.setName
	at com.teleport.host.PortalHostViewManager.setName(SourceFile:2)
	at com.facebook.react.uimanager.ViewManager.updateProperties(SourceFile:35)
	at com.facebook.react.uimanager.ViewManager.createViewInstance(SourceFile:7)
	at com.facebook.react.fabric.mounting.SurfaceMountingManager.createViewUnsafe(SourceFile:68)
	...
```

The orphaned child's `mParent` still points at the dying old host. `parent.removeView` is a no-op on a Fabric-dropped host, and `View.mParent` reflection by literal name throws `NoSuchFieldException` on Android 16 (renamed/restricted hidden API).

### Fix

Two coordinated changes:

1. **`PortalHostView.forceAdoptStuckView(child, index)`**: wraps the protected `ViewGroup.addViewInLayout`, which sets `child.mParent = null` from inside the framework before adding (verified against AOSP `main`). Bypasses both the parent-check in `addView` and the reflection restriction.
2. **`PortalView.onHostAvailable`**: distinguish first-bind (children still physical inside `PortalView`, `super.getChildCount() > 0`) from re-bind (children attached to the previous, now-orphaned host, `ownChildren.isNotEmpty()`). Re-bind path uses `forceAdoptStuckView`.

### Repro

Same as 2/3 — pop+push the host. Without this PR, the second-mount notification fires (after 2/3) but the existing first-bind path is a no-op; once you naturally extend it to call `host.addView(child)` for re-bind, you hit the `IllegalStateException` above. With this PR, content rebinds cleanly across host cycles.

### iOS

Unaffected. UIKit's `[child addSubview:newHost]` auto-handles transferring from any prior superview, and there's no equivalent of the `mParent` reflection problem.

### Companion PRs

- 1/3: NPE in `extractPhysicalChildren` during reparent
- 2/3: keep portals subscribed across `<PortalHost>` remount cycles (must land before this PR's code path is reachable)

----

Claude Code Session ID `6b76118d-edb3-4caa-b168-b1e73dfd6a7a`
