### PR TITLE
fix: specify style for `Portal` so that first render doesn't produce empty screen for preloading example

### DIFF
--- a/docs/docs/recipes/preloading-heavy-components.mdx
+++ b/docs/docs/recipes/preloading-heavy-components.mdx
@@ -133,7 +133,7 @@ import { WebView } from "react-native-webview";
 import { useEditorStore } from "./useEditorStore";
 import { EDITOR_HTML } from "./editorHtml";
 
-const { width } = Dimensions.get("window");
+const { width, height } = Dimensions.get("window");
 
 export default function PreloadedEditor() {
   const hostName = useEditorStore((s) => s.hostName);
@@ -141,7 +141,7 @@ export default function PreloadedEditor() {
 
   return (
     <View style={styles.offscreen}>
-      <Portal hostName={hostName}>
+      <Portal hostName={hostName} style={styles.portal}>
         <WebView
           source={{ html: EDITOR_HTML }}
           style={styles.webview}
@@ -156,8 +156,10 @@ const styles = StyleSheet.create({
   offscreen: {
     position: "absolute",
     top: -9999,
+  },
+  portal: {
     width: width,
-    height: 500,
+    height: height,
   },
   webview: {
     flex: 1,

--- a/example/src/screens/RichTextEditor/PreloadedEditor.tsx
+++ b/example/src/screens/RichTextEditor/PreloadedEditor.tsx
@@ -5,7 +5,7 @@ import { WebView } from "react-native-webview";
 import { useEditorStore } from "./useEditorStore";
 import { EDITOR_HTML } from "./editorHtml";
 
-const { width } = Dimensions.get("window");
+const { width, height } = Dimensions.get("window");
 
 export default function PreloadedEditor() {
   const hostName = useEditorStore((s) => s.hostName);
@@ -13,7 +13,7 @@ export default function PreloadedEditor() {
 
   return (
     <View style={styles.offscreen}>
-      <Portal hostName={hostName} style={{ width }}>
+      <Portal hostName={hostName} style={styles.portal}>
         <WebView
           source={{ html: EDITOR_HTML }}
           style={styles.webview}
@@ -28,7 +28,10 @@ const styles = StyleSheet.create({
   offscreen: {
     position: "absolute",
     top: -9999,
-    height: 500,
+  },
+  portal: {
+    width: width,
+    height: height,
   },
   webview: {
     flex: 1,


### PR DESCRIPTION
## 📜 Description

Fixed a problem when first rendering of preloaded component renders nothing.

## 💡 Motivation and Context

We need to specify a valid frame for preloaded component. Otherwise first time the `height` will be `0` and component will be invisible:

<img width="842" height="142" alt="telegram-cloud-photo-size-2-5460999528040307114-y" src="https://github.com/user-attachments/assets/e2c34964-ad6e-4781-998c-ba8a5eb035d3" />

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- specify valid frame for `Portal`;

### Docs

- specify valid frame for `Portal` in preloading guide;

## 🤔 How Has This Been Tested?

Tested manually on:

- iPhone 16 Pro (iOS 26.2);
- Pixel 7 Pro (Android 16); 

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/94a9b555-4999-4b65-90f8-4810a1b3c376">|<video src="https://github.com/user-attachments/assets/41024c41-9688-437a-b647-ed373d8f7798">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
