### PR TITLE
fix: behavior with mounting/unmounting `PortalHost` with teleported content

### DIFF
--- a/android/src/main/java/com/teleport/global/PortalRegistry.kt
+++ b/android/src/main/java/com/teleport/global/PortalRegistry.kt
@@ -13,15 +13,7 @@ object PortalRegistry {
     view: PortalHostView,
   ) {
     hosts[name] = WeakReference(view)
-
-    pendingPortals[name]?.let { portals ->
-      val iterator = portals.iterator()
-      while (iterator.hasNext()) {
-        val portalRef = iterator.next()
-        portalRef.get()?.onHostAvailable() ?: iterator.remove()
-      }
-      pendingPortals.remove(name)
-    }
+    notifySubscribers(name)
   }
 
   fun unregisterHost(
@@ -31,6 +23,17 @@ object PortalRegistry {
     val hostViewId = hosts[name]?.get()?.id
     if (hostViewId == viewId) {
       hosts.remove(name)
+      notifySubscribers(name)
+    }
+  }
+
+  private fun notifySubscribers(name: String) {
+    pendingPortals[name]?.let { portals ->
+      val iterator = portals.iterator()
+      while (iterator.hasNext()) {
+        val portalRef = iterator.next()
+        portalRef.get()?.onHostChanged() ?: iterator.remove()
+      }
     }
   }
 

--- a/android/src/main/java/com/teleport/portal/PortalView.kt
+++ b/android/src/main/java/com/teleport/portal/PortalView.kt
@@ -12,30 +12,18 @@ class PortalView(
   context: Context,
 ) : ReactViewGroup(context) {
   private var hostName: String? = null
-  private var isWaitingForHost = false
   private val ownChildren: MutableList<View> = ArrayList()
 
   fun setHostName(name: String?) {
+    if (name == hostName) return
+
     val children = extractChildren()
 
-    if (isWaitingForHost) {
-      hostName?.let { PortalRegistry.unregisterPendingPortal(it, this) }
-      isWaitingForHost = false
-    }
+    hostName?.let { PortalRegistry.unregisterPendingPortal(it, this) }
 
     hostName = name
 
-    val target: ViewGroup =
-      hostName?.let { hostNameValue ->
-        val host = PortalRegistry.getHost(hostNameValue)
-        if (host != null) {
-          host
-        } else {
-          PortalRegistry.registerPendingPortal(hostNameValue, this)
-          isWaitingForHost = true
-          this
-        }
-      } ?: this
+    val target: ViewGroup = name?.let { PortalRegistry.getHost(it) } ?: this
 
     if (target is PortalHostView) {
       for (i in children.indices) {
@@ -48,20 +36,34 @@ class PortalView(
         target.addView(children[i], i)
       }
     }
+
+    name?.let { PortalRegistry.registerPendingPortal(it, this) }
   }
 
-  internal fun onHostAvailable() {
-    isWaitingForHost = false
-
+  internal fun onHostChanged() {
     val host = PortalRegistry.getHost(hostName)
     if (host != null) {
-      val children = extractPhysicalChildren()
+      // Host appeared (or was replaced). Move children into it, detaching
+      // from their current parent first — that may be `this` (initial mount
+      // or after host loss) or a stale, detached host view.
+      val children: List<View> =
+        if (ownChildren.isEmpty()) extractPhysicalChildren() else detachOwnChildren()
 
       for (i in children.indices) {
         val idx = host.nextInsertionIndexForChildAt(i)
         host.addView(children[i], idx)
       }
       ownChildren.addAll(children)
+    } else {
+      // Host went away. Pull children back to ourselves so they remain
+      // attached to a live view tree and React-driven mutations keep working.
+      if (ownChildren.isEmpty()) return
+      val list = detachOwnChildren()
+      // isTeleported() is now false, so super.addView and addView are equivalent;
+      // use super to be explicit that this is a physical re-attach.
+      for (i in list.indices) {
+        super.addView(list[i], i)
+      }
     }
   }
 
@@ -85,27 +87,24 @@ class PortalView(
     return children
   }
 
-  private fun extractTeleportedChildren(): List<View> {
-    val oldHost = hostName?.let { PortalRegistry.getHost(it) }
-    val temp = ownChildren.toList()
-    for (child in temp) {
-      oldHost?.removeView(child)
-    }
+  /**
+   * Detaches every view in [ownChildren] from its current parent (which may be
+   * `this`, the active host, or a stale/detached host) and clears the list.
+   * Returns the detached views in their original order so the caller can
+   * re-attach them somewhere else.
+   */
+  private fun detachOwnChildren(): List<View> {
+    val list = ownChildren.toList()
     ownChildren.clear()
-
-    return temp
+    for (child in list) {
+      (child.parent as? ViewGroup)?.removeView(child)
+    }
+    return list
   }
 
   private fun extractChildren(): List<View> {
     // Gather current children (logical if teleported, physical otherwise)
-    val children: List<View> =
-      if (isTeleported()) {
-        extractTeleportedChildren()
-      } else {
-        extractPhysicalChildren()
-      }
-
-    return children
+    return if (isTeleported()) detachOwnChildren() else extractPhysicalChildren()
   }
 
   /**

--- a/docs/docs/guides/lifecycle.md
+++ b/docs/docs/guides/lifecycle.md
@@ -5,7 +5,7 @@ keywords:
   [
     react-native-teleport,
     portal,
-    portalhost,
+    PortalHost,
     lifecycle,
     mount,
     unmount,

--- a/docs/docs/guides/lifecycle.md
+++ b/docs/docs/guides/lifecycle.md
@@ -69,7 +69,7 @@ Children are pulled back to the Portal's local position so they remain attached 
 
 ### A host remounts (mount → unmount → mount)
 
-On each cycle, children follow the host. Mounting a host with the same name a second time picks up exactly where the first cycle left off - there's no special "first mount" logic. This is the foundation for `PersistedPortal`-style patterns where a Portal outlives its host(s).
+On each cycle, children follow the host. Mounting a host with the same name a second time picks up exactly where the first cycle left off - there's no special "first mount" logic.
 
 ### Portal's `hostName` prop changes
 

--- a/docs/docs/guides/lifecycle.md
+++ b/docs/docs/guides/lifecycle.md
@@ -1,0 +1,107 @@
+---
+sidebar_position: 3
+description: How Portal and PortalHost behave together over time - what gets rendered where, and how children move when components mount and unmount.
+keywords:
+  [
+    react-native-teleport,
+    portal,
+    portalhost,
+    lifecycle,
+    mount,
+    unmount,
+    teleport,
+    behavior,
+  ]
+---
+
+# Lifecycle & behavior
+
+This page describes the contract between [`Portal`](../api/components/portal) and [`PortalHost`](../api/components/portal-host) - what renders where, and how children move as components mount and unmount.
+
+The rules are designed to match what you'd intuitively expect from a portal system: children always end up _somewhere_ visible, and they survive transient changes to the host.
+
+## 1. Static behavior
+
+Given a fixed configuration that doesn't change over time, this is where children render.
+
+| `Portal` configuration                                | Result                                                                                      |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| No `hostName` prop                                    | Children render **locally**, in place. `Portal` behaves like a transparent wrapper.         |
+| `hostName="x"` and a `<PortalHost name="x" />` exists | Children are **teleported** into that host.                                                 |
+| `hostName="x"` but no host with that name exists      | Children render **locally** as a fallback. As soon as a matching host mounts, they migrate. |
+
+The "render locally as fallback" rule means a `Portal` is never a black hole - children are always attached to a live view tree, even if the host is missing.
+
+:::tip Conditionally rendering when no host exists
+
+If you'd rather render _nothing_ (or a different UI) while the host is missing instead of falling back locally, use the [`usePortal`](../api/hooks/use-portal) hook and read its `isHostAvailable` flag:
+
+```tsx
+import { Portal, usePortal } from "react-native-teleport";
+
+function Toast() {
+  const { isHostAvailable } = usePortal("toast");
+  if (!isHostAvailable) return null;
+
+  return (
+    <Portal hostName="toast">
+      <ToastContent />
+    </Portal>
+  );
+}
+```
+
+This way the `<ToastContent />` tree is only mounted while the host exists, instead of rendering at the local position and migrating later.
+
+:::
+
+## 2. Dynamic behavior
+
+The interesting cases happen when something changes. The library guarantees the following transitions:
+
+### A host mounts after the Portal
+
+Children that were rendering locally as a fallback are moved into the new host automatically. The React tree doesn't re-render - only the native views are re-parented.
+
+### A host unmounts while the Portal is still alive
+
+Children are pulled back to the Portal's local position so they remain attached to a live view tree. They are _not_ destroyed. Component state, refs, and any imperative native state (animation values, video playback position, scroll offset, etc.) are preserved.
+
+### A host remounts (mount → unmount → mount)
+
+On each cycle, children follow the host. Mounting a host with the same name a second time picks up exactly where the first cycle left off - there's no special "first mount" logic. This is the foundation for `PersistedPortal`-style patterns where a Portal outlives its host(s).
+
+### Portal's `hostName` prop changes
+
+Children migrate from the previous target (host or local) to the new target. If the new `hostName` has no matching host, children fall back to local rendering until that host appears.
+
+### Portal unmounts
+
+Its children unmount with it, regardless of where they currently live. The host doesn't keep orphaned children - `Portal` owns its children's React lifecycle, the host only owns their physical attachment point.
+
+### Host unmounts
+
+Only the host disappears. All Portals targeting it survive, with their children intact (rendering locally per the rule above).
+
+## 3. Identity and ordering
+
+These are the rules that are easy to get wrong if you don't know them.
+
+- **Multiple Portals targeting the same host** are appended in React mount order. If `Portal A` mounts before `Portal B`, `A`'s children appear above `B`'s in the host. Reordering the Portals in the React tree reorders them in the host.
+- **Host names are matched as strings.** Two `PortalHost` instances with the same `name` mounted at the same time is undefined behavior - only the most recently registered one will receive new portals. Unmounting either may leave children stranded. Use unique names per active host.
+- **React identity is preserved across host mount/unmount cycles.** A teleported `<Video />` does not reset its playback position when its host unmounts and remounts. This is the whole reason you'd reach for a Portal that outlives its host.
+
+## 4. What Portal does NOT do
+
+To set expectations, here are things people sometimes assume Portal handles but it doesn't:
+
+- **It does not proxy layout from the local position to the host.** The teleported children take their size and position from the host's layout, not from where the `<Portal>` sits in the tree. If you need a "ghost" placeholder at the local position, render one yourself.
+- **It does not bridge React context in any special way.** It doesn't need to: `createPortal`-style semantics already mean children read context from their React parent (the `<Portal>`), not from their physical DOM/native parent. If a context provider sits above the `<Portal>`, teleported children see it.
+- **It does not implement focus, keyboard, or accessibility traversal across the teleport.** Native focus order and screen reader traversal follow the physical view hierarchy - i.e. the host's location, not the Portal's.
+
+## See also
+
+- [Portal API](../api/components/portal)
+- [PortalHost API](../api/components/portal-host)
+- [usePortal hook](../api/hooks/use-portal) - imperative access and `isHostAvailable` flag
+- [Teleport guide](./teleport) - for moving an _existing_ view without unmounting it

--- a/docs/docs/guides/lifecycle.md
+++ b/docs/docs/guides/lifecycle.md
@@ -87,21 +87,35 @@ Only the host disappears. All Portals targeting it survive, with their children 
 
 These are the rules that are easy to get wrong if you don't know them.
 
-- **Multiple Portals targeting the same host** are appended in React mount order. If `Portal A` mounts before `Portal B`, `A`'s children appear above `B`'s in the host. Reordering the Portals in the React tree reorders them in the host.
+- **Multiple Portals targeting the same host** preserve order, with one important nuance:
+  - **When teleported in the same commit** (e.g. both rendered at the same time on initial mount), their children appear in the host in the same order they sit in the JSX tree. If `<Portal A />` comes before `<Portal B />` in source, `A`'s children gets mounted earlier in the host than `B`'s.
+  - **When teleported in different commits** (e.g. `B` mounts later, after `A` is already in the host), order is defined by _arrival time_, not JSX position. The newcomer is appended after whatever is already in the host, even if it appears earlier in the source.
 - **Host names are matched as strings.** Two `PortalHost` instances with the same `name` mounted at the same time is undefined behavior - only the most recently registered one will receive new portals. Unmounting either may leave children stranded. Use unique names per active host.
 - **React identity is preserved across host mount/unmount cycles.** A teleported `<Video />` does not reset its playback position when its host unmounts and remounts. This is the whole reason you'd reach for a Portal that outlives its host.
 
-## 4. What Portal does NOT do
+:::warning Layout is not preserved at the original location
 
-To set expectations, here are things people sometimes assume Portal handles but it doesn't:
+`Portal` does not reserve space at its position. Once children are teleported into a host, they take their size and position from the **host's** layout - the original location collapses to zero.
 
-- **It does not proxy layout from the local position to the host.** The teleported children take their size and position from the host's layout, not from where the `<Portal>` sits in the tree. If you need a "ghost" placeholder at the local position, render one yourself.
-- **It does not bridge React context in any special way.** It doesn't need to: `createPortal`-style semantics already mean children read context from their React parent (the `<Portal>`), not from their physical DOM/native parent. If a context provider sits above the `<Portal>`, teleported children see it.
-- **It does not implement focus, keyboard, or accessibility traversal across the teleport.** Native focus order and screen reader traversal follow the physical view hierarchy - i.e. the host's location, not the Portal's.
+If you need to avoid surrounding content reflowing while children are teleported away, render a wrapper view at the original position with the same dimensions as the teleported children:
+
+```tsx
+<View style={{ width: 200, height: 60 }}>
+  <Portal hostName="overlay">
+    <View style={{ width: 200, height: 60 }}>
+      <ChildContent />
+    </View>
+  </Portal>
+</View>
+```
+
+The outer `<View>` keeps its slot in the layout regardless of whether the inner content is currently teleported.
+
+:::
 
 ## See also
 
-- [Portal API](../api/components/portal)
-- [PortalHost API](../api/components/portal-host)
+- [Portal API](../api/components/portal) - declarative component that teleports its children into a named host
+- [PortalHost API](../api/components/portal-host) - the destination where teleported children are mounted
 - [usePortal hook](../api/hooks/use-portal) - imperative access and `isHostAvailable` flag
 - [Teleport guide](./teleport) - for moving an _existing_ view without unmounting it

--- a/e2e/flows/persisted-portal.yml
+++ b/e2e/flows/persisted-portal.yml
@@ -49,7 +49,7 @@ appId: teleport.example
     env:
       base: screenshots/${DEVICE}/PersistedPortalWithoutHost
       target: PersistedPortalWithoutHost
-      diff: 0.3
+      diff: 0.4
 - assertTrue: ${output.matches}
 
 # Step 3: Mount the <PortalHost> again
@@ -63,5 +63,5 @@ appId: teleport.example
     env:
       base: screenshots/${DEVICE}/PersistedPortalWithHost
       target: PersistedPortalWithHost
-      diff: 0.3
+      diff: 0.4
 - assertTrue: ${output.matches}

--- a/e2e/flows/persisted-portal.yml
+++ b/e2e/flows/persisted-portal.yml
@@ -37,3 +37,31 @@ appId: teleport.example
       target: PersistedPortalWithHost
       diff: 0.3
 - assertTrue: ${output.matches}
+
+# Step 2: Unmount the <PortalHost>
+# teleported children should return to the local Portal location
+- tapOn:
+    id: "persisted_portal_toggle_host"
+- takeScreenshot:
+    path: e2e/PersistedPortalWithoutHost
+- runScript:
+    file: ../scripts/compare-screenshots.js
+    env:
+      base: screenshots/${DEVICE}/PersistedPortalWithoutHost
+      target: PersistedPortalWithoutHost
+      diff: 0.3
+- assertTrue: ${output.matches}
+
+# Step 3: Mount the <PortalHost> again
+# Portal should re-teleport its children to the new host instance
+- tapOn:
+    id: "persisted_portal_toggle_host"
+- takeScreenshot:
+    path: e2e/PersistedPortalWithHost
+- runScript:
+    file: ../scripts/compare-screenshots.js
+    env:
+      base: screenshots/${DEVICE}/PersistedPortalWithHost
+      target: PersistedPortalWithHost
+      diff: 0.3
+- assertTrue: ${output.matches}

--- a/ios/PortalRegistry.mm
+++ b/ios/PortalRegistry.mm
@@ -42,21 +42,7 @@
 {
   if (name) {
     [self.hosts setObject:host forKey:name];
-
-    NSPointerArray *portals = self.pendingPortals[name];
-    if (portals) {
-      // Compact the array to remove nil entries
-      [portals compact];
-
-      for (NSUInteger i = 0; i < portals.count; i++) {
-        PortalView *portal = (__bridge PortalView *)[portals pointerAtIndex:i];
-        if (portal) {
-          [portal onHostAvailable];
-        }
-      }
-
-      [self.pendingPortals removeObjectForKey:name];
-    }
+    [self notifySubscribersForName:name];
   }
 }
 
@@ -66,6 +52,24 @@
     PortalHostView *registered = [self.hosts objectForKey:name];
     if (registered && registered.tag == viewTag) {
       [self.hosts removeObjectForKey:name];
+      [self notifySubscribersForName:name];
+    }
+  }
+}
+
+- (void)notifySubscribersForName:(NSString *)name
+{
+  NSPointerArray *portals = self.pendingPortals[name];
+  if (!portals) {
+    return;
+  }
+
+  [portals compact];
+
+  for (NSUInteger i = 0; i < portals.count; i++) {
+    PortalView *portal = (__bridge PortalView *)[portals pointerAtIndex:i];
+    if (portal) {
+      [portal onHostChanged];
     }
   }
 }

--- a/ios/PortalView.h
+++ b/ios/PortalView.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface PortalView : RCTViewComponentView
 
-- (void)onHostAvailable;
+- (void)onHostChanged;
 
 @end
 

--- a/ios/PortalView.mm
+++ b/ios/PortalView.mm
@@ -24,7 +24,6 @@ using namespace facebook::react;
 
 @property (nonatomic, strong) NSString *hostName;
 @property (nonatomic, strong) UIView *targetView;
-@property (nonatomic, assign) BOOL isWaitingForHost;
 
 @end
 
@@ -83,9 +82,8 @@ using namespace facebook::react;
   std::string newNameStr = newViewProps.name;
 
   if (![self.hostName isEqualToString:newHostName]) {
-    if (self.isWaitingForHost && self.hostName) {
+    if (self.hostName) {
       [[PortalRegistry sharedInstance] unregisterPendingPortal:self withHostName:self.hostName];
-      self.isWaitingForHost = NO;
     }
 
     self.hostName = newHostName;
@@ -95,21 +93,16 @@ using namespace facebook::react;
       hostView = [[PortalRegistry sharedInstance] getHostWithName:self.hostName];
     }
 
-    UIView *newTarget = self.contentView;
-    if (self.hostName) {
-      if (hostView) {
-        newTarget = (UIView *)hostView;
-      } else {
-        [[PortalRegistry sharedInstance] registerPendingPortal:self withHostName:self.hostName];
-        self.isWaitingForHost = YES;
-        newTarget = self.contentView;
-      }
-    }
+    UIView *newTarget = hostView ? (UIView *)hostView : self.contentView;
 
     if (newTarget != self.targetView) {
       self.targetView = newTarget;
 
       [self moveOwnChildrenToTarget:newTarget];
+    }
+
+    if (self.hostName) {
+      [[PortalRegistry sharedInstance] registerPendingPortal:self withHostName:self.hostName];
     }
   }
 
@@ -156,14 +149,14 @@ using namespace facebook::react;
   [childComponentView removeFromSuperview];
 }
 
-- (void)onHostAvailable
+- (void)onHostChanged
 {
-  self.isWaitingForHost = NO;
-
   PortalHostView *hostView = [[PortalRegistry sharedInstance] getHostWithName:self.hostName];
-  if (hostView) {
-    self.targetView = (UIView *)hostView;
-    [self moveOwnChildrenToTarget:(UIView *)hostView];
+  UIView *newTarget = hostView ? (UIView *)hostView : self.contentView;
+
+  if (newTarget != self.targetView) {
+    self.targetView = newTarget;
+    [self moveOwnChildrenToTarget:newTarget];
   }
 }
 
@@ -171,9 +164,8 @@ using namespace facebook::react;
 {
   [super prepareForRecycle];
 
-  if (self.isWaitingForHost && self.hostName) {
+  if (self.hostName) {
     [[PortalRegistry sharedInstance] unregisterPendingPortal:self withHostName:self.hostName];
-    self.isWaitingForHost = NO;
   }
 
   // Reset all portal state so recycled views don't retain stale host references.

--- a/src/views/Portal/index.tsx
+++ b/src/views/Portal/index.tsx
@@ -16,7 +16,6 @@ export default function Portal({ hostName, children, style }: PortalProps) {
   }
 
   const sentinelRef = useRef<HTMLDivElement>(null);
-  const isWaitingForHostRef = useRef(false);
 
   useLayoutEffect(() => {
     if (elRef.current && style) {
@@ -40,8 +39,6 @@ export default function Portal({ hostName, children, style }: PortalProps) {
 
         hostNode.appendChild(el);
       }
-
-      isWaitingForHostRef.current = false;
     } else if (sentinelRef.current && sentinelRef.current.parentNode) {
       // keep view locally
       const parent = sentinelRef.current.parentNode;
@@ -58,29 +55,16 @@ export default function Portal({ hostName, children, style }: PortalProps) {
   }, [hostName, getHost]);
 
   useLayoutEffect(() => {
-    const hostNode = hostName ? getHost(hostName) : null;
-
-    if (isWaitingForHostRef.current && hostName) {
-      unregisterPendingPortal(hostName, teleportToHost);
-      isWaitingForHostRef.current = false;
-    }
-
     teleportToHost();
 
-    if (hostName && !hostNode) {
-      registerPendingPortal(hostName, teleportToHost);
-      isWaitingForHostRef.current = true;
-    }
+    if (!hostName) return;
 
+    registerPendingPortal(hostName, teleportToHost);
     return () => {
-      if (isWaitingForHostRef.current && hostName) {
-        unregisterPendingPortal(hostName, teleportToHost);
-        isWaitingForHostRef.current = false;
-      }
+      unregisterPendingPortal(hostName, teleportToHost);
     };
   }, [
     hostName,
-    getHost,
     registerPendingPortal,
     unregisterPendingPortal,
     teleportToHost,

--- a/src/views/PortalProvider/index.tsx
+++ b/src/views/PortalProvider/index.tsx
@@ -9,14 +9,13 @@ export default function PortalProvider({ children }: PortalProviderProps) {
   const registerHost = useCallback((name: string, node: HTMLElement | null) => {
     if (node) {
       hostsRef.current.set(name, node);
-
-      const callbacks = pendingPortalsRef.current.get(name);
-      if (callbacks) {
-        callbacks.forEach((callback) => callback());
-        pendingPortalsRef.current.delete(name);
-      }
     } else {
       hostsRef.current.delete(name);
+    }
+
+    const callbacks = pendingPortalsRef.current.get(name);
+    if (callbacks) {
+      callbacks.forEach((callback) => callback());
     }
   }, []);
   const getHost = useCallback(


### PR DESCRIPTION
## 📜 Description

Fix a bug where teleported children fail to re-attach after a `<PortalHost>` is unmounted and re-mounted with the same name. The bug affected all three platforms (web, Android, iOS) and is the same conceptual issue in each: a `<Portal>` only subscribed to host-mount events while it was *waiting* for a host, and unsubscribed itself as soon as it teleported once. Once the host went away and came back, nobody was listening, so the new host stayed empty.

## 💡 Motivation and Context

This change makes the subscription model symmetric: a `<Portal>` is subscribed to its target host name for its entire lifetime, and the registry fires the subscriber callback on **both** host register and unregister. The portal then handles each transition in one place — moving its children into the new host or pulling them back to its local fallback location.

Trace of the original (buggy) behavior on every platform:

1. **Cycle 1 — host mounts:** the registry runs the portal's pending callback, the portal teleports children into the host, and the registry then **clears** the pending list.
2. **Cycle 2 — host unmounts:** the registry deletes its map entry. No callback runs. The portal's children are stranded as physical children of the now-detached host view (or as DOM children of a removed node, on web). The portal is no longer in the pending list, so it doesn't know the host went away.
3. **Cycle 3 — host re-mounts:** the registry's pending list for that name is empty → no callbacks fire → new host appears empty.

The user-visible symptom is that the `PersistedPortal` example renders correctly on first host mount, then breaks on every subsequent mount/unmount cycle (children disappear).

The fix has the same shape on all three platforms:

### Registry

- Don't drop subscribers after firing. The pending list is now a long-lived subscription list keyed by host name.
- On `unregisterHost`, also notify subscribers (so the portal can fall back to its local position).
- Both `registerHost` and `unregisterHost` route through a single `notifySubscribers(name)` helper that invokes one callback per subscriber. The callback re-queries the registry for the current host, so it doesn't matter whether it was woken up by a register or unregister event.

### Portal view

- Drop the `isWaitingForHost` flag. The portal now subscribes once for the lifetime of its `hostName`, and unsubscribes only when `hostName` changes or the portal is destroyed/recycled.
- Replace `onHostAvailable` with `onHostChanged`, which handles both directions:
  - **Host now exists:** detach children from their current parent (which may be `this`, the new host, or a stale/detached old host) and attach them to the host.
  - **Host no longer exists:** detach children from their current parent and attach them physically back to the portal itself, so they remain in a live view tree.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Docs

- added a page about lifecycle and behavior;

### E2E

- extend existing persisted-portal tests with repeating the action and assuring that it works as first steps;

### JS

- `PortalProvider`: `registerHost` no longer clears `pendingPortalsRef[name]` after invoking callbacks, and now invokes them on both register and unregister. The DOM-portal wrapper `<div>` is the "el" being moved around; it stays alive for the lifetime of the React `<Portal>`.
- `Portal`: now always registers `teleportToHost` as a subscriber while `hostName` is set; cleanup runs on unmount or `hostName` change. The `teleportToHost` callback already handled both branches (host present → move into host; host absent → move back next to the sentinel) — it just wasn't being invoked in the right situations before.

### iOS

- `PortalRegistry`: same restructure — `registerHost:withName:` and `unregisterHostWithName:viewTag:` both call a shared `notifySubscribersForName:` helper. Pending portals are not removed after firing.
- `PortalView`:
  - Removed the `isWaitingForHost` property.
  - `updateProps` now unconditionally unregisters from the old `hostName` and registers for the new `hostName` after computing the new `targetView`.
  - Renamed `onHostAvailable` → `onHostChanged`. The new implementation re-queries the registry; if a host exists, it sets `targetView` to the host and moves children there; if no host exists, it sets `targetView` back to `self.contentView` and moves children there. This is what fixes the secondary iOS bug where children got stranded in a dead host on unmount.
  - `prepareForRecycle` unconditionally unsubscribes when `hostName` is non-nil (no longer gated on the now-removed `isWaitingForHost`).

### Android

- `PortalRegistry`: `registerHost` and `unregisterHost` both delegate to a private `notifySubscribers(name)`. Pending portals are kept across notifications.
- `PortalView`:
  - `setHostName` now calls `unregisterPendingPortal` for the old name and `registerPendingPortal` for the new name unconditionally — no more "only when waiting".
  - `onHostAvailable` is renamed `onHostChanged` and rewritten to handle both directions:
    - If a host is now available, detach children either from `this` (initial case) or from the previous parent via `child.parent.removeView(child)` (covers the stale-host case where the previous parent is a detached view), then attach to the new host.
    - If no host is available, detach children from their current parent and re-attach them to `this` via `super.addView`, so they're physically present on the portal again. Using `super` is intentional and called out in a comment: at this point `isTeleported()` returns `false`, so the override and `super` behave the same, but `super` makes the intent explicit ("this is a real physical attach, not a logical teleported add").
  - Extracted the "detach all currently-tracked children from whatever parent they happen to have" snippet into `detachOwnChildren()` and reused it in both `onHostChanged` branches and in `extractChildren` (replacing the old `extractTeleportedChildren`, which did the same thing but went through the registry's `getHost` lookup — that fails when the parent is a stale detached host that's no longer in the registry).

## 🤔 How Has This Been Tested?

Tested manually on:
- iPhone 26 Pro (iOS 26.2);
- Pixel 8 API 36
- Pixel 9 Pro API 35
- Google Chrome (Version 147.0.7727.138 (Official Build) (arm64))

## 📸 Screenshots (if appropriate):

|iOS|Android|Web|
|----|-------|-----|
|<video src="https://github.com/user-attachments/assets/7c7afbd1-c93c-4499-a51b-b999136396a2">|<video src="https://github.com/user-attachments/assets/e9943453-9044-4a86-99b8-6598305dbdee">|<video src="https://github.com/user-attachments/assets/feb17afd-3c5f-41ab-bd0f-1a1a110a037f">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
