### PR TITLE
fix: crash on Android hot reloading

### DIFF
--- a/android/src/main/java/com/teleport/global/PortalRegistry.kt
+++ b/android/src/main/java/com/teleport/global/PortalRegistry.kt
@@ -44,6 +44,7 @@ object PortalRegistry {
     portal: PortalView,
   ) {
     val portals = pendingPortals.getOrPut(hostName) { mutableListOf() }
+    portals.removeAll { it.get() == null || it.get() == portal }
     portals.add(WeakReference(portal))
   }
 

--- a/android/src/main/java/com/teleport/host/PortalHostView.kt
+++ b/android/src/main/java/com/teleport/host/PortalHostView.kt
@@ -41,5 +41,8 @@ class PortalHostView(
 
   fun cleanup(viewId: Int) {
     name?.let { PortalRegistry.unregisterHost(it, viewId) }
+    name = null
+    isInBatch = false
+    batchBaseIndex = 0
   }
 }

--- a/android/src/main/java/com/teleport/portal/PortalView.kt
+++ b/android/src/main/java/com/teleport/portal/PortalView.kt
@@ -67,6 +67,12 @@ class PortalView(
     }
   }
 
+  fun cleanup() {
+    hostName?.let { PortalRegistry.unregisterPendingPortal(it, this) }
+    detachOwnChildren()
+    hostName = null
+  }
+
   private fun isTeleported(): Boolean = hostName != null && PortalRegistry.getHost(hostName) != null
 
   private fun extractPhysicalChildren(): List<View> {
@@ -94,10 +100,20 @@ class PortalView(
    * re-attach them somewhere else.
    */
   private fun detachOwnChildren(): List<View> {
-    val list = ownChildren.toList()
+    val list = ArrayList<View>(ownChildren.size)
+    for (child in ownChildren) {
+      if (!list.contains(child)) {
+        list.add(child)
+      }
+    }
     ownChildren.clear()
     for (child in list) {
-      (child.parent as? ViewGroup)?.removeView(child)
+      val parent = child.parent as? ViewGroup
+      if (parent === this) {
+        super.removeView(child)
+      } else {
+        parent?.removeView(child)
+      }
     }
     return list
   }

--- a/android/src/main/java/com/teleport/portal/PortalViewManager.kt
+++ b/android/src/main/java/com/teleport/portal/PortalViewManager.kt
@@ -21,6 +21,11 @@ class PortalViewManager :
 
   override fun createTeleportView(context: ThemedReactContext): ReactViewGroup = PortalView(context)
 
+  override fun onDropViewInstance(view: ReactViewGroup) {
+    (view as? PortalView)?.cleanup()
+    super.onDropViewInstance(view)
+  }
+
   @ReactProp(name = "name")
   override fun setName(
     view: ReactViewGroup?,


### PR DESCRIPTION
## 📜 Description

Fixed a crash on Android when performing a hot reload.

## 💡 Motivation and Context

When we reload the app we restart the Activity. Before we didn't clean up the attached children and we were trying to attach them twice afterwards which was leading to crash:

```bash
java.lang.IllegalStateException: The specified child already has a parent. You must call removeView() on the child's parent first.
  at android.view.ViewGroup.addViewInner(ViewGroup.java:5286)
  at android.view.ViewGroup.addView(ViewGroup.java:5115)
  at android.view.ViewGroup.addView(ViewGroup.java:5055)
```

In this PR I fixed that - I detect a moment when view is getting destroyed and clean up all internal resources. In this way we avoid the crash 🤞 

Closes https://github.com/kirillzyusko/react-native-teleport/issues/129

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- added `cleanup` to `PortalView`;
- call `cleanup` in `PortalViewManager` on `onDropViewInstance`;

## 🤔 How Has This Been Tested?

Tested manually on Pixel 8 (API 36).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/6373388f-cdcb-4f9d-890d-832071660b57">|<video src="https://github.com/user-attachments/assets/7b2efed1-7dc9-4104-8eb0-3f0f4595d826">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
