### PR TITLE
refactor: reduce code duplication

### DIFF
--- a/src/views/Portal/index.tsx
+++ b/src/views/Portal/index.tsx
@@ -7,6 +7,24 @@ import type { PortalProps } from "../../types";
 
 const supportsMoveBefore =
   typeof Element !== "undefined" && "moveBefore" in Element.prototype;
+
+function moveElementTo(
+  parent: Element,
+  child: Element,
+  before: Element | null = null,
+) {
+  if (supportsMoveBefore && child.parentNode) {
+    parent.moveBefore(child, before);
+    return;
+  }
+
+  if (child.parentNode) {
+    child.parentNode.removeChild(child);
+  }
+
+  parent.insertBefore(child, before);
+}
+
 export default function Portal({ hostName, children, style }: PortalProps) {
   const { getHost, registerPendingPortal, unregisterPendingPortal } =
     usePortalRegistryContext();
@@ -30,27 +48,11 @@ export default function Portal({ hostName, children, style }: PortalProps) {
     const hostNode = hostName ? getHost(hostName) : null;
     if (hostNode) {
       // teleport view to the host
-      if (supportsMoveBefore && el.parentNode) {
-        hostNode.moveBefore(el, null);
-      } else {
-        if (el.parentNode) {
-          el.parentNode.removeChild(el);
-        }
-
-        hostNode.appendChild(el);
-      }
-    } else if (sentinelRef.current && sentinelRef.current.parentNode) {
+      moveElementTo(hostNode, el);
+    } else if (sentinelRef.current && sentinelRef.current.parentElement) {
       // keep view locally
-      const parent = sentinelRef.current.parentNode;
-
-      if (supportsMoveBefore && el.parentNode) {
-        parent.moveBefore(el, sentinelRef.current);
-      } else {
-        if (el.parentNode) {
-          el.parentNode.removeChild(el);
-        }
-        parent.insertBefore(el, sentinelRef.current);
-      }
+      const parent = sentinelRef.current.parentElement;
+      moveElementTo(parent, el, sentinelRef.current);
     }
   }, [hostName, getHost]);
 


### PR DESCRIPTION
## 📜 Description

Reduced code duplication.

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The original changes that added `if`-branching were here: https://github.com/kirillzyusko/react-native-teleport/pull/87

In this PR I created separate function that moves an element between containers.

Even though we have bigger code size and more lines such separation helps to improve code readability, so let's sacrifice microcode optimizations in sake of readability 🤞 

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- added `moveElementTo` helper function that switches implementation to new/old API depending whether browser support it or not;

## 🤔 How Has This Been Tested?

Tested via e2e tests.

## 📸 Screenshots (if appropriate):

No visual changes.

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
