### PR TITLE
fix: `prepareToRecycleView` function signature mismatch

### DIFF
--- a/android/src/main/java/com/teleport/managers/TeleportViewManager.kt
+++ b/android/src/main/java/com/teleport/managers/TeleportViewManager.kt
@@ -19,7 +19,7 @@ abstract class TeleportViewManager : ReactViewManager() {
   override fun prepareToRecycleView(
     reactContext: ThemedReactContext,
     view: ReactViewGroup,
-  ): ReactViewGroup? {
+  ): ReactViewGroup {
     super.prepareToRecycleView(reactContext, view)
     forceBoxNone(view)
     return view


### PR DESCRIPTION
## 📜 Description

In older RN versions `prepareToRecycleView` should return non-null version.

## 💡 Motivation and Context

It seems like in Java this type was non-null (0.79.x), in latest Kotlin version it can be nullable. In order not to break compilation on older versions I marked signature of method to return non-null type. We anyway receive non-nullable type so we can return it as well. It will give us a confidence that compilation will not break for wider range of RN versions 🤞 

Fixes https://github.com/kirillzyusko/react-native-teleport/issues/137

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- make return type of `prepareToRecycleView` non-nullable;

## 🤔 How Has This Been Tested?

Tested via CI.

## 📸 Screenshots (if appropriate):

<img width="801" height="295" alt="image" src="https://github.com/user-attachments/assets/5a6f8a82-1ddf-4801-848d-a0e93f92b21b" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
