### PR TITLE
fix(android): clear dangling parent link when re-attaching after host teardown

### DIFF
--- a/android/src/main/java/com/teleport/portal/PortalView.kt
+++ b/android/src/main/java/com/teleport/portal/PortalView.kt
@@ -108,14 +108,35 @@ class PortalView(
     }
     ownChildren.clear()
     for (child in list) {
-      val parent = child.parent as? ViewGroup
+      val parent = child.parent as? ViewGroup ?: continue
       if (parent === this) {
         super.removeView(child)
       } else {
-        parent?.removeView(child)
+        val idx = parent.indexOfChild(child)
+        if (idx >= 0) parent.removeViewAt(idx) else parent.removeView(child)
+      }
+      // A torn-down host can be left holding a dangling parent link: the child
+      // is gone from the host's child list (childCount 0 / indexOfChild -1) but
+      // child.getParent() still points at it, so removeView is a no-op. Clear
+      // the stale back-reference so the caller can re-attach without throwing.
+      if (child.parent != null) {
+        forceClearParent(child)
       }
     }
     return list
+  }
+
+  // Clears a dangling parent pointer that removeView can't (the parent no longer
+  // lists the child, and View.mParent reflection is blocked on API 28+):
+  // re-adopt via attachViewToParent (no parent check), then remove cleanly.
+  private fun forceClearParent(child: View) {
+    try {
+      val params = child.layoutParams ?: generateDefaultLayoutParams()
+      attachViewToParent(child, super.getChildCount(), params)
+      super.removeView(child)
+    } catch (_: Throwable) {
+      // Best effort; nothing safer exists for a child of a dead parent.
+    }
   }
 
   private fun extractChildren(): List<View> {


### PR DESCRIPTION
Fixes #140

## Problem

On Android (Fabric), `PortalView` reclaims teleported children via `detachOwnChildren` (used by `setHostName`'s `extractChildren` and the `onHostChanged` host-teardown path) and re-adds them. The re-add throws:

```
IllegalStateException: The specified child already has a parent. You must call removeView() on the child's parent first.
  at com.teleport.portal.PortalView.addView(PortalView.kt)
  at com.teleport.portal.PortalView.setHostName(PortalView.kt)
```

When a screen unmounts, its `PortalHostView` is emptied (`childCount == 0`) but the teleported child's `mParent` still points at that dead host (`indexOfChild == -1`). `detachOwnChildren`'s `parent?.removeView(child)` is a no-op (the child isn't in the host's list), so the child is returned still "parented" and the re-add throws. See #140 for the on-device trace.

## Fix

Handle the dangling link in `detachOwnChildren` — the single helper both reclaim paths go through:

1. **Normal removal first** — `removeView` / `removeViewAt` on the actual parent, keeping that parent's child array consistent. Covers the common cases.
2. **Dangling-pointer fallback** — only if `child.parent != null` afterward, `forceClearParent` re-adopts the child onto the `PortalView` via `attachViewToParent` (which skips the `addViewInner` "already has a parent" check), then `super.removeView` nulls the link cleanly.

`attachViewToParent` is used only as a fallback: it reassigns `mParent` without unlinking the child from its *current* parent's array, so it's only safe when that array is already empty (the stale case). `View.mParent` reflection is blocked on API 28+, so that isn't an option. The `addView` overrides are untouched.

## Testing

Reproduced with a persistent WebView teleported between screen-level `PortalHost`s (crashed reliably on navigating away). Verified fixed on a Pixel 9 emulator and a physical device: the dangling pointer is cleared (`afterParent == null`) and there are no crashes across repeated navigations; teleported content still renders after returning.

Happy to move the cleanup into the host-teardown path (`PortalHostView`) instead if you'd prefer to prevent the dangling state rather than repair it on reclaim.