### PR TITLE
fix: `IllegalStateException` when navigating back and teleporting children to offscreen

### DIFF
--- a/android/src/main/java/com/teleport/host/PortalHostView.kt
+++ b/android/src/main/java/com/teleport/host/PortalHostView.kt
@@ -12,6 +12,7 @@ class PortalHostView(
   private var name: String? = null
   private var isInBatch = false
   private var batchBaseIndex = 0
+  private var pendingCleanupViewId: Int? = null
 
   /**
    * Returns the index at which a portal child should be inserted.
@@ -40,9 +41,25 @@ class PortalHostView(
   }
 
   fun cleanup(viewId: Int) {
+    if (isAttachedToWindow) {
+      pendingCleanupViewId = viewId
+      return
+    }
+
+    cleanupNow(viewId)
+  }
+
+  override fun onDetachedFromWindow() {
+    super.onDetachedFromWindow()
+
+    pendingCleanupViewId?.let { cleanupNow(it) }
+  }
+
+  private fun cleanupNow(viewId: Int) {
     name?.let { PortalRegistry.unregisterHost(it, viewId) }
     name = null
     isInBatch = false
     batchBaseIndex = 0
+    pendingCleanupViewId = null
   }
 }

--- a/android/src/main/java/com/teleport/portal/PortalView.kt
+++ b/android/src/main/java/com/teleport/portal/PortalView.kt
@@ -88,9 +88,21 @@ class PortalView(
       super.getChildAt(i)?.let { children.add(it) }
     }
     for (child in children) {
-      super.removeView(child)
+      detachFromParent(child)
     }
     return children
+  }
+
+  private fun detachFromParent(child: View) {
+    val parent = child.parent as? ViewGroup ?: return
+    if (parent === this) {
+      super.removeView(child)
+    } else {
+      parent.removeView(child)
+    }
+    if (child.parent === parent) {
+      parent.endViewTransition(child)
+    }
   }
 
   /**
@@ -108,12 +120,7 @@ class PortalView(
     }
     ownChildren.clear()
     for (child in list) {
-      val parent = child.parent as? ViewGroup
-      if (parent === this) {
-        super.removeView(child)
-      } else {
-        parent?.removeView(child)
-      }
+      detachFromParent(child)
     }
     return list
   }


### PR DESCRIPTION
## 📜 Description

Fixed `IllegalStateException` when user closes screen and teleport the content back to offscreen.

## 💡 Motivation and Context

### Why is this change required? 🤔 

On Android, when a `PortalHostView` is removed during a native-stack screen dismissal, `react-native-screens` can keep child views in an active native view transition. In that state, calling `removeView(...)` may remove the child from the host’s child list, but the child can still report the old host as its parent.

When Teleport then tries to move the child back to the offscreen `PortalView`, Android throws:

`The specified child already has a parent. You must call removeView() on the child's parent first.`

### What problem does it solve? 🤓 

This fixes a crash that happens when a teleported child is moved away from a `PortalHostView` while the host is being dismissed as part of a native navigation transition.

It also keeps the teleported content visible during the screen dismissal animation. The host is now unregistered only after it is detached from the window, so the portal moves back offscreen after the native transition instead of disappearing immediately when navigation starts.

### Why was this solution selected? ❓ 

The fix targets the Android lifecycle behavior that causes the crash:

- if `removeView(...)` does not fully detach the child, `endViewTransition(child)` completes the pending native transition bookkeeping;
- if the host is still attached to the window, host cleanup is deferred until `onDetachedFromWindow()`.

This keeps the change small and localized to Android native portal/host lifecycle handling without changing the public API, JS behavior, registry model, or example app structure.

### Which other alternatives were considered? 🔢 

One alternative was to force-clear the stale parent pointer by temporarily attaching the child to another parent and removing it again. That can work as a fallback, but it relies on lower-level `ViewGroup` behavior and is more of a recovery workaround than a lifecycle fix.

Another option was to unregister the host immediately and only make child detachment more defensive. That fixes the crash, but it causes the teleported content to disappear at the start of the navigation animation.

A larger redesign of the portal registry or host ownership model was also unnecessary for this issue.

### Why is this the correct solution? ✅ 

The root cause is Android view-transition state during native screen removal. `endViewTransition(child)` is the platform API meant to finish that state, and `onDetachedFromWindow()` is the correct point to know that the host is no longer visually participating in the screen transition.

As a result, the child is detached safely, the crash is avoided, and the visual behavior matches the navigation lifecycle.

Closes https://github.com/kirillzyusko/react-native-teleport/issues/140 https://github.com/kirillzyusko/react-native-teleport/pull/141

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- add `detachFromParent` helper;
- use `endViewTransition` inside `detachFromParent`;
- use `detachFromParent` instead of `super.removeView`;
- added `cleanupNow` to `PortalHostView`;
- call `cleanupNow` only when view is really detached (not removed) to keep it onscreen while screen is dismissing;

## 🤔 How Has This Been Tested?

Tested manually on Pixel 9 Pro (API 35). Also tested https://github.com/kirillzyusko/react-native-teleport/issues/65 manually to avoid potential regressions:

https://github.com/user-attachments/assets/ff8fa40e-dc9c-423d-bac8-9ae2771b7d55

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/772e6308-9206-442b-aa5d-e3d192d6d6d7">|<video src="https://github.com/user-attachments/assets/171259f5-1dc1-4b08-bac8-611b85147a59">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
