### PR TITLE
feat: add navigation ownership e2e test

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -73,7 +73,8 @@
     "reparenting",
     "portaling",
     "segoe",
-    "picsum"
+    "picsum",
+    "subflows"
   ],
   "ignorePaths": [
     "node_modules",

--- a/e2e/flows/navigation-view-ownership.yml
+++ b/e2e/flows/navigation-view-ownership.yml
@@ -11,6 +11,10 @@ appId: teleport.example
       - swipe:
           start: 50%, 80%
           end: 50%, 20%
+# do additional swipe for headless web, this is Maestro bug
+- swipe:
+    start: 50%, 75%
+    end: 50%, 55%
 - tapOn:
     id: "rich_text_editor"
 

--- a/e2e/flows/navigation-view-ownership.yml
+++ b/e2e/flows/navigation-view-ownership.yml
@@ -1,0 +1,27 @@
+appId: teleport.example
+---
+- launchApp
+
+# Scroll to the Rich Text Editor example.
+- repeat:
+    while:
+      notVisible:
+        id: "rich_text_editor"
+    commands:
+      - swipe:
+          start: 50%, 80%
+          end: 50%, 20%
+- tapOn:
+    id: "rich_text_editor"
+
+# Teleport the preloaded editor into the screen-local host.
+- tapOn:
+    id: "rich_text_editor_preloaded"
+- assertVisible:
+    text: "Pre-loaded Editor"
+
+# Dismiss the parent native-stack screen while the editor is teleported.
+- tapOn:
+    id: "rich_text_editor_back"
+- assertVisible:
+    id: "rich_text_editor"

--- a/e2e/flows/navigation-view-ownership.yml
+++ b/e2e/flows/navigation-view-ownership.yml
@@ -21,7 +21,7 @@ appId: teleport.example
     text: "Pre-loaded Editor"
 
 # Dismiss the parent native-stack screen while the editor is teleported.
-- tapOn:
-    id: "rich_text_editor_back"
+- runFlow:
+    file: ../subflows/go-back.yml
 - assertVisible:
     id: "rich_text_editor"

--- a/e2e/subflows/go-back.yml
+++ b/e2e/subflows/go-back.yml
@@ -1,0 +1,24 @@
+appId: teleport.example
+---
+# Maestro web exposes this stack back button by its accessibility label instead
+# of the React Native Web data-testid.
+- runFlow:
+    when:
+      platform: Web
+    commands:
+      - tapOn:
+          id: "Examples, back"
+
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn:
+          id: "go_back"
+
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - tapOn:
+          id: "go_back"

--- a/example/src/navigation/ExamplesStack/index.tsx
+++ b/example/src/navigation/ExamplesStack/index.tsx
@@ -230,7 +230,7 @@ const ExamplesStack = () => (
           <HeaderBackButton
             label={label}
             onPress={() => navigation.goBack()}
-            testID="rich_text_editor_back"
+            testID="go_back"
             tintColor={tintColor}
           />
         ),

--- a/example/src/navigation/ExamplesStack/index.tsx
+++ b/example/src/navigation/ExamplesStack/index.tsx
@@ -2,6 +2,7 @@ import {
   createNativeStackNavigator,
   type NativeStackNavigationProp,
 } from "@react-navigation/native-stack";
+import { HeaderBackButton } from "@react-navigation/elements";
 
 import { ScreenNames } from "../../constants/screenNames";
 import GestureHandlerTouchableExample from "../../screens/Touchable";
@@ -223,7 +224,17 @@ const ExamplesStack = () => (
     <Stack.Screen
       component={RichTextEditor}
       name={ScreenNames.RICH_TEXT_EDITOR}
-      options={options[ScreenNames.RICH_TEXT_EDITOR]}
+      options={({ navigation }) => ({
+        ...options[ScreenNames.RICH_TEXT_EDITOR],
+        headerLeft: ({ label, tintColor }) => (
+          <HeaderBackButton
+            label={label}
+            onPress={() => navigation.goBack()}
+            testID="rich_text_editor_back"
+            tintColor={tintColor}
+          />
+        ),
+      })}
     />
     <Stack.Screen
       component={PersistedPortal}

--- a/example/src/screens/RichTextEditor/index.tsx
+++ b/example/src/screens/RichTextEditor/index.tsx
@@ -60,6 +60,7 @@ export default function RichTextEditorExample() {
           <TouchableOpacity
             style={[styles.card, styles.cardHighlight]}
             onPress={openPreloaded}
+            testID="rich_text_editor_preloaded"
           >
             <Text style={[styles.cardTitle, styles.cardTitleHighlight]}>
               Pre-loaded (Teleport)


### PR DESCRIPTION
## 📜 Description

Added a test for https://github.com/kirillzyusko/react-native-teleport/pull/142

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

More tests = better quality of the package. I'm doing it in separate PR because didn't have to land it in original fix.

> [!NOTE]
> This test doesn't crash the app on CI. I don't know why, maybe because we use `x86_64` arch. But it fails locally so it would be fair to include it too.

Tests for https://github.com/kirillzyusko/react-native-teleport/pull/142

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### E2E

- added navigation ownership test;

## 🤔 How Has This Been Tested?

Tested locally and via CI.

## 📸 Screenshots (if appropriate):

<img width="817" height="387" alt="image" src="https://github.com/user-attachments/assets/6728623b-0329-4d70-8ffb-9e753a9bc183" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
