### PR TITLE
fix: iOS 27 example app compatibility

### DIFF
--- a/example/ios/TeleportExample.xcodeproj/project.pbxproj
+++ b/example/ios/TeleportExample.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		66BDE8CAF7ED411794BDBD63 /* Urbanist-Italic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 431AE9C12B154E58B28517BD /* Urbanist-Italic.ttf */; };
 		761780ED2CA45674006654EE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761780EC2CA45674006654EE /* AppDelegate.swift */; };
+		761780EF2E00A000006654EE /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 761780EE2E00A000006654EE /* SceneDelegate.swift */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
 		8C86E4776B66E30D0FC31B5A /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */; };
 		BE3E9A6D672348AFBC15F479 /* Urbanist-ExtraBold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 38F62F8569964905A26CDA1B /* Urbanist-ExtraBold.ttf */; };
@@ -31,6 +32,7 @@
 		5709B34CF0A7D63546082F79 /* Pods-TeleportExample.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TeleportExample.release.xcconfig"; path = "Target Support Files/Pods-TeleportExample/Pods-TeleportExample.release.xcconfig"; sourceTree = "<group>"; };
 		5DCACB8F33CDC322A6C60F78 /* libPods-TeleportExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-TeleportExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		761780EC2CA45674006654EE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = TeleportExample/AppDelegate.swift; sourceTree = "<group>"; };
+		761780EE2E00A000006654EE /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SceneDelegate.swift; path = TeleportExample/SceneDelegate.swift; sourceTree = "<group>"; };
 		7D8C4EEE55FD4DA585C580F7 /* Urbanist-SemiBold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Urbanist-SemiBold.ttf"; path = "../assets/fonts/Urbanist-SemiBold.ttf"; sourceTree = "<group>"; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = TeleportExample/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		BC061485FB5044C583633F55 /* Urbanist-Bold.ttf */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = undefined; includeInIndex = 0; lastKnownFileType = unknown; name = "Urbanist-Bold.ttf"; path = "../assets/fonts/Urbanist-Bold.ttf"; sourceTree = "<group>"; };
@@ -54,6 +56,7 @@
 			children = (
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
 				761780EC2CA45674006654EE /* AppDelegate.swift */,
+				761780EE2E00A000006654EE /* SceneDelegate.swift */,
 				13B07FB61A68108700A75B9A /* Info.plist */,
 				81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */,
 				13B07FB81A68108700A75B9A /* PrivacyInfo.xcprivacy */,
@@ -276,6 +279,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				761780ED2CA45674006654EE /* AppDelegate.swift in Sources */,
+				761780EF2E00A000006654EE /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/example/ios/TeleportExample/AppDelegate.swift
+++ b/example/ios/TeleportExample/AppDelegate.swift
@@ -9,11 +9,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
   var reactNativeDelegate: ReactNativeDelegate?
   var reactNativeFactory: RCTReactNativeFactory?
+  private var launchOptions: [UIApplication.LaunchOptionsKey: Any]?
 
   func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
+    self.launchOptions = launchOptions
+
     let delegate = ReactNativeDelegate()
     let factory = RCTReactNativeFactory(delegate: delegate)
     delegate.dependencyProvider = RCTAppDependencyProvider()
@@ -21,15 +24,30 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     reactNativeDelegate = delegate
     reactNativeFactory = factory
 
-    window = UIWindow(frame: UIScreen.main.bounds)
+    return true
+  }
 
-    factory.startReactNative(
+  func application(
+    _ application: UIApplication,
+    configurationForConnecting connectingSceneSession: UISceneSession,
+    options: UIScene.ConnectionOptions
+  ) -> UISceneConfiguration {
+    let configuration = UISceneConfiguration(
+      name: "Default Configuration",
+      sessionRole: connectingSceneSession.role
+    )
+    configuration.delegateClass = SceneDelegate.self
+    return configuration
+  }
+
+  func startReactNative(in window: UIWindow) {
+    self.window = window
+
+    reactNativeFactory?.startReactNative(
       withModuleName: "TeleportExample",
       in: window,
       launchOptions: launchOptions
     )
-
-    return true
   }
 }
 

--- a/example/ios/TeleportExample/Info.plist
+++ b/example/ios/TeleportExample/Info.plist
@@ -35,6 +35,23 @@
 	<string/>
 	<key>RCTNewArchEnabled</key>
 	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/example/ios/TeleportExample/SceneDelegate.swift
+++ b/example/ios/TeleportExample/SceneDelegate.swift
@@ -1,0 +1,22 @@
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+  var window: UIWindow?
+
+  func scene(
+    _ scene: UIScene,
+    willConnectTo session: UISceneSession,
+    options connectionOptions: UIScene.ConnectionOptions
+  ) {
+    guard
+      let windowScene = scene as? UIWindowScene,
+      let appDelegate = UIApplication.shared.delegate as? AppDelegate
+    else {
+      return
+    }
+
+    let window = UIWindow(windowScene: windowScene)
+    self.window = window
+    appDelegate.startReactNative(in: window)
+  }
+}


### PR DESCRIPTION
## 📜 Description

Fixed app crash at app launch on iOS 27 for iOS example projects.

## 💡 Motivation and Context

The iOS example apps crashed on launch when built with the latest iOS SDK because UIKit now requires apps to adopt the `UIScene` lifecycle. The examples still created their main `UIWindow` directly from `AppDelegate` and did not declare a scene manifest.

This change migrates the example apps to scene-based lifecycle startup so they can launch correctly with the current SDK.

## 📢 Changelog

### iOS

- added `SceneDelegate` support for the example and Fabric example apps.
- added `UIApplicationSceneManifest` entries and moved React Native window startup into the scene lifecycle.

## 🤔 How Has This Been Tested?

Tested manually using XCode 27 beta (iOS 27, iPhone 17 Pro, simulator).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<img width="1448" height="892" alt="image" src="https://github.com/user-attachments/assets/fa869847-331f-48e8-828a-49bb6a51cddc" />|<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/3701d720-3288-457f-b55f-97bc729448dd" />|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
