### PR TITLE
fix: duplicated `root` hosts in example app

### DIFF
--- a/example/src/screens/TeleportationOrder/index.tsx
+++ b/example/src/screens/TeleportationOrder/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { StyleSheet, Text, View, Pressable } from "react-native";
-import { Portal, PortalProvider } from "react-native-teleport";
+import { Portal, PortalHost } from "react-native-teleport";
 
 interface DialogProps {
   open: boolean;
@@ -14,7 +14,7 @@ function Dialog(props: DialogProps) {
   const { open, onClose, title, message, children } = props;
   if (!open) return null;
   return (
-    <Portal hostName="root">
+    <Portal hostName="dialog">
       <View style={styles.overlay}>
         <View style={styles.dialog}>
           <Text style={styles.title}>{title}</Text>
@@ -41,63 +41,63 @@ export default function TeleportationOrder() {
   const [thirdDialogOpen, setThirdDialogOpen] = useState(false);
 
   return (
-    <PortalProvider>
-      <View style={styles.container}>
-        <Text style={styles.header}>Nested Dialogs Example</Text>
-        <Text style={styles.subtitle}>Open dialogs within dialogs</Text>
+    <View style={styles.container}>
+      <Text style={styles.header}>Nested Dialogs Example</Text>
+      <Text style={styles.subtitle}>Open dialogs within dialogs</Text>
 
+      <Pressable
+        style={({ pressed }) => [
+          styles.buttonPrimary,
+          pressed && styles.buttonPrimaryPressed,
+        ]}
+        onPress={() => setFirstDialogOpen(true)}
+      >
+        <Text style={styles.buttonPrimaryText}>Open First Dialog</Text>
+      </Pressable>
+
+      <Dialog
+        open={firstDialogOpen}
+        onClose={() => setFirstDialogOpen(false)}
+        title="First Dialog"
+        message="This is the first dialog. You can open another dialog from here."
+      >
+        <Pressable
+          style={({ pressed }) => [
+            styles.buttonOutline,
+            pressed && styles.buttonOutlinePressed,
+          ]}
+          onPress={() => setSecondDialogOpen(true)}
+        >
+          <Text style={styles.buttonOutlineText}>Open Second Dialog</Text>
+        </Pressable>
+      </Dialog>
+
+      <Dialog
+        open={secondDialogOpen}
+        onClose={() => setSecondDialogOpen(false)}
+        title="Second Dialog"
+        message="This is the second dialog, opened from the first one. Go even deeper?"
+      >
         <Pressable
           style={({ pressed }) => [
             styles.buttonPrimary,
             pressed && styles.buttonPrimaryPressed,
           ]}
-          onPress={() => setFirstDialogOpen(true)}
+          onPress={() => setThirdDialogOpen(true)}
         >
-          <Text style={styles.buttonPrimaryText}>Open First Dialog</Text>
+          <Text style={styles.buttonPrimaryText}>Open Third Dialog</Text>
         </Pressable>
+      </Dialog>
 
-        <Dialog
-          open={firstDialogOpen}
-          onClose={() => setFirstDialogOpen(false)}
-          title="First Dialog"
-          message="This is the first dialog. You can open another dialog from here."
-        >
-          <Pressable
-            style={({ pressed }) => [
-              styles.buttonOutline,
-              pressed && styles.buttonOutlinePressed,
-            ]}
-            onPress={() => setSecondDialogOpen(true)}
-          >
-            <Text style={styles.buttonOutlineText}>Open Second Dialog</Text>
-          </Pressable>
-        </Dialog>
+      <Dialog
+        open={thirdDialogOpen}
+        onClose={() => setThirdDialogOpen(false)}
+        title="Third Dialog"
+        message="You've reached the third level of nested dialogs! 🎉"
+      />
 
-        <Dialog
-          open={secondDialogOpen}
-          onClose={() => setSecondDialogOpen(false)}
-          title="Second Dialog"
-          message="This is the second dialog, opened from the first one. Go even deeper?"
-        >
-          <Pressable
-            style={({ pressed }) => [
-              styles.buttonPrimary,
-              pressed && styles.buttonPrimaryPressed,
-            ]}
-            onPress={() => setThirdDialogOpen(true)}
-          >
-            <Text style={styles.buttonPrimaryText}>Open Third Dialog</Text>
-          </Pressable>
-        </Dialog>
-
-        <Dialog
-          open={thirdDialogOpen}
-          onClose={() => setThirdDialogOpen(false)}
-          title="Third Dialog"
-          message="You've reached the third level of nested dialogs! 🎉"
-        />
-      </View>
-    </PortalProvider>
+      <PortalHost name="dialog" style={StyleSheet.absoluteFill} />
+    </View>
   );
 }
 


### PR DESCRIPTION
## 📜 Description

Fixed an issue with:
- inconsistent `root`/`overlay` rendering (we had duplicated hosts)
- visiting Teleportation order breaks other example screens (because we cleanup dimensions on screen unmount).

## 💡 Motivation and Context

Keeping 2 `PortalProvider` is wrong, because when we close a screen we run a cleanup. Also both hosts share the same name while being rendered in two different part of trees with different layout.

I fixed the issue by using unique name 🤞 Now if we use `dialog` as name everything works well. The issue https://github.com/kirillzyusko/react-native-teleport/issues/148 is still reproducible if we render it in `overlay`/`root` hosts.

That being said I'll merge this PR and will keep working on https://github.com/kirillzyusko/react-native-teleport/issues/148

We also had a similar issue in the past but with a different name: https://github.com/kirillzyusko/react-native-teleport/pull/37 🤦‍♂️ 

Closes https://github.com/kirillzyusko/react-native-teleport/issues/86

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- don't use `PortalProvider` again on screen level;
- introduce `dialog` specific host on screen level (to avoid host's names pollution).

## 🤔 How Has This Been Tested?

Tested on iPhone 17 Pro (iOS 26.2), Pixel 7 Pro (API 36), Google Chrome. `dialog` renders within a screen, `overlay`/`root` covers whole window.

## 📸 Screenshots (if appropriate):

<img width="1206" height="2622" alt="image" src="https://github.com/user-attachments/assets/37d9e6d7-2b79-48ca-8193-1f9d2d0317f9" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
