### PR TITLE
fix: cancelled `onPress` handler from `Pressable`

### DIFF
--- a/android/src/main/java/com/teleport/extensions/Float.kt
+++ b/android/src/main/java/com/teleport/extensions/Float.kt
@@ -1,0 +1,12 @@
+package com.teleport.extensions
+
+import android.content.res.Resources
+
+internal val Float.dp: Double
+  get() = (this / displayDensity).toDouble()
+
+internal val Float.px: Double
+  get() = (this * displayDensity).toDouble()
+
+private val displayDensity: Float
+  get() = Resources.getSystem().displayMetrics.density

--- a/android/src/main/java/com/teleport/extensions/View.kt
+++ b/android/src/main/java/com/teleport/extensions/View.kt
@@ -1,0 +1,8 @@
+package com.teleport.extensions
+
+import android.view.View
+
+internal fun View.screenLocation(): IntArray =
+  IntArray(2).also {
+    getLocationOnScreen(it)
+  }

--- a/android/src/main/java/com/teleport/extensions/View.kt
+++ b/android/src/main/java/com/teleport/extensions/View.kt
@@ -6,3 +6,5 @@ internal fun View.screenLocation(): IntArray =
   IntArray(2).also {
     getLocationOnScreen(it)
   }
+
+internal fun View.isDetached(): Boolean = !isAttachedToWindow

--- a/android/src/main/java/com/teleport/global/PortalRegistry.kt
+++ b/android/src/main/java/com/teleport/global/PortalRegistry.kt
@@ -37,6 +37,16 @@ object PortalRegistry {
     }
   }
 
+  fun notifyHostLayoutChanged(name: String) {
+    pendingPortals[name]?.let { portals ->
+      val iterator = portals.iterator()
+      while (iterator.hasNext()) {
+        val portalRef = iterator.next()
+        portalRef.get()?.onHostLayoutChanged() ?: iterator.remove()
+      }
+    }
+  }
+
   fun getHost(name: String?): PortalHostView? = hosts[name]?.get()
 
   fun registerPendingPortal(

--- a/android/src/main/java/com/teleport/host/PortalHostView.kt
+++ b/android/src/main/java/com/teleport/host/PortalHostView.kt
@@ -40,6 +40,22 @@ class PortalHostView(
     newName?.let { PortalRegistry.registerHost(it, this) }
   }
 
+  override fun onLayout(
+    changed: Boolean,
+    left: Int,
+    top: Int,
+    right: Int,
+    bottom: Int,
+  ) {
+    super.onLayout(changed, left, top, right, bottom)
+    name?.let { PortalRegistry.notifyHostLayoutChanged(it) }
+  }
+
+  override fun onAttachedToWindow() {
+    super.onAttachedToWindow()
+    name?.let { PortalRegistry.notifyHostLayoutChanged(it) }
+  }
+
   fun cleanup(viewId: Int) {
     if (isAttachedToWindow) {
       pendingCleanupViewId = viewId

--- a/android/src/main/java/com/teleport/host/PortalHostView.kt
+++ b/android/src/main/java/com/teleport/host/PortalHostView.kt
@@ -14,6 +14,27 @@ class PortalHostView(
   private var batchBaseIndex = 0
   private var pendingCleanupViewId: Int? = null
 
+  // region ViewManager methods
+  fun setName(newName: String?) {
+    if (name == newName) return
+
+    name?.let { PortalRegistry.unregisterHost(it, id) }
+    name = newName
+    newName?.let { PortalRegistry.registerHost(it, this) }
+  }
+
+  fun cleanup(viewId: Int) {
+    if (isAttachedToWindow) {
+      pendingCleanupViewId = viewId
+      return
+    }
+
+    cleanupNow(viewId)
+  }
+  // endregion
+
+  // region Portal insertion
+
   /**
    * Returns the index at which a portal child should be inserted.
    *
@@ -31,15 +52,9 @@ class PortalHostView(
     }
     return minOf(batchBaseIndex + childIndex, childCount)
   }
+  // endregion
 
-  fun setName(newName: String?) {
-    if (name == newName) return
-
-    name?.let { PortalRegistry.unregisterHost(it, id) }
-    name = newName
-    newName?.let { PortalRegistry.registerHost(it, this) }
-  }
-
+  // region Lifecycle
   override fun onLayout(
     changed: Boolean,
     left: Int,
@@ -56,21 +71,14 @@ class PortalHostView(
     name?.let { PortalRegistry.notifyHostLayoutChanged(it) }
   }
 
-  fun cleanup(viewId: Int) {
-    if (isAttachedToWindow) {
-      pendingCleanupViewId = viewId
-      return
-    }
-
-    cleanupNow(viewId)
-  }
-
   override fun onDetachedFromWindow() {
     super.onDetachedFromWindow()
 
     pendingCleanupViewId?.let { cleanupNow(it) }
   }
+  // endregion
 
+  // region Helpers
   private fun cleanupNow(viewId: Int) {
     name?.let { PortalRegistry.unregisterHost(it, viewId) }
     name = null
@@ -78,4 +86,5 @@ class PortalHostView(
     batchBaseIndex = 0
     pendingCleanupViewId = null
   }
+  // endregion
 }

--- a/android/src/main/java/com/teleport/host/PortalHostView.kt
+++ b/android/src/main/java/com/teleport/host/PortalHostView.kt
@@ -66,11 +66,6 @@ class PortalHostView(
     name?.let { PortalRegistry.notifyHostLayoutChanged(it) }
   }
 
-  override fun onAttachedToWindow() {
-    super.onAttachedToWindow()
-    name?.let { PortalRegistry.notifyHostLayoutChanged(it) }
-  }
-
   override fun onDetachedFromWindow() {
     super.onDetachedFromWindow()
 

--- a/android/src/main/java/com/teleport/portal/PortalLayoutStateController.kt
+++ b/android/src/main/java/com/teleport/portal/PortalLayoutStateController.kt
@@ -1,0 +1,125 @@
+package com.teleport.portal
+
+import android.view.View
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.uimanager.PixelUtil
+import com.facebook.react.uimanager.StateWrapper
+import com.teleport.host.PortalHostView
+import kotlin.math.abs
+
+internal class PortalLayoutStateController(
+  private val sourceView: View,
+) {
+  private var lastHostLayout: HostLayoutState? = null
+  private var stateWrapper: StateWrapper? = null
+
+  fun setStateWrapper(wrapper: StateWrapper?) {
+    stateWrapper = wrapper
+  }
+
+  fun updateIfNeeded(
+    hostName: String?,
+    host: PortalHostView?,
+  ) {
+    val wrapper = stateWrapper
+    val shouldReset = shouldReset(hostName, host)
+
+    when {
+      wrapper == null -> Unit
+      shouldReset -> resetIfNeeded()
+      host == null || !hasMeasuredSize(host) -> Unit
+      else -> publishIfChanged(wrapper, createHostLayoutState(host))
+    }
+  }
+
+  fun resetIfNeeded() {
+    val wrapper = stateWrapper
+    val needsReset = wrapper != null && lastHostLayout?.hasHostLayout != false
+
+    if (needsReset) {
+      lastHostLayout = HostLayoutState.EMPTY
+      wrapper?.updateState(HostLayoutState.EMPTY.toMap())
+    }
+  }
+
+  private fun shouldReset(
+    hostName: String?,
+    host: PortalHostView?,
+  ): Boolean = hostName == null || host == null || viewsAreDetached(host)
+
+  private fun viewsAreDetached(host: PortalHostView): Boolean =
+    !sourceView.isAttachedToWindow || !host.isAttachedToWindow
+
+  private fun hasMeasuredSize(host: PortalHostView): Boolean = host.width != 0 && host.height != 0
+
+  private fun publishIfChanged(
+    wrapper: StateWrapper,
+    nextState: HostLayoutState,
+  ) {
+    if (lastHostLayout?.nearlyEquals(nextState) != true) {
+      lastHostLayout = nextState
+      wrapper.updateState(nextState.toMap())
+    }
+  }
+
+  private fun createHostLayoutState(host: PortalHostView): HostLayoutState {
+    val sourceLocation = sourceView.screenLocation()
+    val hostLocation = host.screenLocation()
+
+    return HostLayoutState(
+      width = PixelUtil.toDIPFromPixel(host.width.toFloat()),
+      height = PixelUtil.toDIPFromPixel(host.height.toFloat()),
+      offsetX = PixelUtil.toDIPFromPixel((hostLocation[0] - sourceLocation[0]).toFloat()),
+      offsetY = PixelUtil.toDIPFromPixel((hostLocation[1] - sourceLocation[1]).toFloat()),
+      hasHostLayout = true,
+    )
+  }
+}
+
+private data class HostLayoutState(
+  val width: Float,
+  val height: Float,
+  val offsetX: Float,
+  val offsetY: Float,
+  val hasHostLayout: Boolean,
+) {
+  fun nearlyEquals(other: HostLayoutState): Boolean =
+    hasHostLayout == other.hasHostLayout &&
+      hasSameSize(other) &&
+      hasSameOffset(other)
+
+  private fun hasSameSize(other: HostLayoutState): Boolean =
+    width.nearlyEquals(other.width) && height.nearlyEquals(other.height)
+
+  private fun hasSameOffset(other: HostLayoutState): Boolean =
+    offsetX.nearlyEquals(other.offsetX) && offsetY.nearlyEquals(other.offsetY)
+
+  fun toMap() =
+    Arguments.createMap().apply {
+      putDouble("width", width.toDouble())
+      putDouble("height", height.toDouble())
+      putDouble("offsetX", offsetX.toDouble())
+      putDouble("offsetY", offsetY.toDouble())
+      putBoolean("hasHostLayout", hasHostLayout)
+    }
+
+  companion object {
+    val EMPTY =
+      HostLayoutState(
+        width = 0f,
+        height = 0f,
+        offsetX = 0f,
+        offsetY = 0f,
+        hasHostLayout = false,
+      )
+  }
+}
+
+private fun View.screenLocation(): IntArray =
+  IntArray(2).also {
+    getLocationOnScreen(it)
+  }
+
+private fun Float.nearlyEquals(other: Float): Boolean = abs(this - other) < STATE_EPSILON
+
+private const val STATE_EPSILON = 0.01f

--- a/android/src/main/java/com/teleport/portal/PortalLayoutStateController.kt
+++ b/android/src/main/java/com/teleport/portal/PortalLayoutStateController.kt
@@ -4,6 +4,7 @@ import android.view.View
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.StateWrapper
+import com.teleport.extensions.isDetached
 import com.teleport.extensions.screenLocation
 import com.teleport.host.PortalHostView
 
@@ -49,7 +50,7 @@ internal class PortalLayoutStateController(
       host
     }
 
-  private fun viewsAreDetached(host: PortalHostView): Boolean = !sourceView.isAttachedToWindow || !host.isAttachedToWindow
+  private fun viewsAreDetached(host: PortalHostView): Boolean = sourceView.isDetached() || host.isDetached()
 
   private fun publishIfChanged(
     wrapper: StateWrapper,

--- a/android/src/main/java/com/teleport/portal/PortalLayoutStateController.kt
+++ b/android/src/main/java/com/teleport/portal/PortalLayoutStateController.kt
@@ -4,13 +4,13 @@ import android.view.View
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.StateWrapper
+import com.teleport.extensions.screenLocation
 import com.teleport.host.PortalHostView
-import kotlin.math.abs
 
 internal class PortalLayoutStateController(
   private val sourceView: View,
 ) {
-  private var lastHostLayout: HostLayoutState? = null
+  private var lastOffset = PortalOffsetState.EMPTY
   private var stateWrapper: StateWrapper? = null
 
   fun setStateWrapper(wrapper: StateWrapper?) {
@@ -22,104 +22,71 @@ internal class PortalLayoutStateController(
     host: PortalHostView?,
   ) {
     val wrapper = stateWrapper
-    val shouldReset = shouldReset(hostName, host)
+    val activeHost = activeHost(hostName, host)
 
     when {
       wrapper == null -> Unit
-      shouldReset -> resetIfNeeded()
-      host == null || !hasMeasuredSize(host) -> Unit
-      else -> publishIfChanged(wrapper, createHostLayoutState(host))
+      activeHost == null -> resetIfNeeded()
+      else -> publishIfChanged(wrapper, createOffsetState(activeHost))
     }
   }
 
   fun resetIfNeeded() {
     val wrapper = stateWrapper
-    val needsReset = wrapper != null && lastHostLayout?.hasHostLayout != false
 
-    if (needsReset) {
-      lastHostLayout = HostLayoutState.EMPTY
-      wrapper?.updateState(HostLayoutState.EMPTY.toMap())
+    if (wrapper != null) {
+      publishIfChanged(wrapper, PortalOffsetState.EMPTY)
     }
   }
 
-  private fun shouldReset(
+  private fun activeHost(
     hostName: String?,
     host: PortalHostView?,
-  ): Boolean = hostName == null || host == null || viewsAreDetached(host)
+  ): PortalHostView? =
+    if (hostName == null || host == null || viewsAreDetached(host)) {
+      null
+    } else {
+      host
+    }
 
-  private fun viewsAreDetached(host: PortalHostView): Boolean =
-    !sourceView.isAttachedToWindow || !host.isAttachedToWindow
-
-  private fun hasMeasuredSize(host: PortalHostView): Boolean = host.width != 0 && host.height != 0
+  private fun viewsAreDetached(host: PortalHostView): Boolean = !sourceView.isAttachedToWindow || !host.isAttachedToWindow
 
   private fun publishIfChanged(
     wrapper: StateWrapper,
-    nextState: HostLayoutState,
+    nextOffset: PortalOffsetState,
   ) {
-    if (lastHostLayout?.nearlyEquals(nextState) != true) {
-      lastHostLayout = nextState
-      wrapper.updateState(nextState.toMap())
+    if (lastOffset != nextOffset) {
+      lastOffset = nextOffset
+      wrapper.updateState(nextOffset.toMap())
     }
   }
 
-  private fun createHostLayoutState(host: PortalHostView): HostLayoutState {
+  private fun createOffsetState(host: PortalHostView): PortalOffsetState {
     val sourceLocation = sourceView.screenLocation()
     val hostLocation = host.screenLocation()
 
-    return HostLayoutState(
-      width = PixelUtil.toDIPFromPixel(host.width.toFloat()),
-      height = PixelUtil.toDIPFromPixel(host.height.toFloat()),
+    return PortalOffsetState(
       offsetX = PixelUtil.toDIPFromPixel((hostLocation[0] - sourceLocation[0]).toFloat()),
       offsetY = PixelUtil.toDIPFromPixel((hostLocation[1] - sourceLocation[1]).toFloat()),
-      hasHostLayout = true,
     )
   }
 }
 
-private data class HostLayoutState(
-  val width: Float,
-  val height: Float,
+private data class PortalOffsetState(
   val offsetX: Float,
   val offsetY: Float,
-  val hasHostLayout: Boolean,
 ) {
-  fun nearlyEquals(other: HostLayoutState): Boolean =
-    hasHostLayout == other.hasHostLayout &&
-      hasSameSize(other) &&
-      hasSameOffset(other)
-
-  private fun hasSameSize(other: HostLayoutState): Boolean =
-    width.nearlyEquals(other.width) && height.nearlyEquals(other.height)
-
-  private fun hasSameOffset(other: HostLayoutState): Boolean =
-    offsetX.nearlyEquals(other.offsetX) && offsetY.nearlyEquals(other.offsetY)
-
   fun toMap() =
     Arguments.createMap().apply {
-      putDouble("width", width.toDouble())
-      putDouble("height", height.toDouble())
       putDouble("offsetX", offsetX.toDouble())
       putDouble("offsetY", offsetY.toDouble())
-      putBoolean("hasHostLayout", hasHostLayout)
     }
 
   companion object {
     val EMPTY =
-      HostLayoutState(
-        width = 0f,
-        height = 0f,
+      PortalOffsetState(
         offsetX = 0f,
         offsetY = 0f,
-        hasHostLayout = false,
       )
   }
 }
-
-private fun View.screenLocation(): IntArray =
-  IntArray(2).also {
-    getLocationOnScreen(it)
-  }
-
-private fun Float.nearlyEquals(other: Float): Boolean = abs(this - other) < STATE_EPSILON
-
-private const val STATE_EPSILON = 0.01f

--- a/android/src/main/java/com/teleport/portal/PortalLayoutStateController.kt
+++ b/android/src/main/java/com/teleport/portal/PortalLayoutStateController.kt
@@ -2,8 +2,8 @@ package com.teleport.portal
 
 import android.view.View
 import com.facebook.react.bridge.Arguments
-import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.StateWrapper
+import com.teleport.extensions.dp
 import com.teleport.extensions.isDetached
 import com.teleport.extensions.screenLocation
 import com.teleport.host.PortalHostView
@@ -67,27 +67,27 @@ internal class PortalLayoutStateController(
     val hostLocation = host.screenLocation()
 
     return PortalOffsetState(
-      offsetX = PixelUtil.toDIPFromPixel((hostLocation[0] - sourceLocation[0]).toFloat()),
-      offsetY = PixelUtil.toDIPFromPixel((hostLocation[1] - sourceLocation[1]).toFloat()),
+      offsetX = (hostLocation[0] - sourceLocation[0]).toFloat().dp,
+      offsetY = (hostLocation[1] - sourceLocation[1]).toFloat().dp,
     )
   }
 }
 
 private data class PortalOffsetState(
-  val offsetX: Float,
-  val offsetY: Float,
+  val offsetX: Double,
+  val offsetY: Double,
 ) {
   fun toMap() =
     Arguments.createMap().apply {
-      putDouble("offsetX", offsetX.toDouble())
-      putDouble("offsetY", offsetY.toDouble())
+      putDouble("offsetX", offsetX)
+      putDouble("offsetY", offsetY)
     }
 
   companion object {
     val EMPTY =
       PortalOffsetState(
-        offsetX = 0f,
-        offsetY = 0f,
+        offsetX = 0.0,
+        offsetY = 0.0,
       )
   }
 }

--- a/android/src/main/java/com/teleport/portal/PortalView.kt
+++ b/android/src/main/java/com/teleport/portal/PortalView.kt
@@ -16,6 +16,10 @@ class PortalView(
   private val layoutStateController = PortalLayoutStateController(this)
   private val ownChildren: MutableList<View> = ArrayList()
 
+  private val isTeleported: Boolean
+    get() = hostName != null && PortalRegistry.getHost(hostName) != null
+
+  // region ViewManager methods
   fun setStateWrapper(wrapper: StateWrapper?) {
     layoutStateController.setStateWrapper(wrapper)
     layoutStateController.updateIfNeeded(hostName, PortalRegistry.getHost(hostName))
@@ -48,6 +52,16 @@ class PortalView(
     layoutStateController.updateIfNeeded(hostName, PortalRegistry.getHost(hostName))
   }
 
+  fun cleanup() {
+    hostName?.let { PortalRegistry.unregisterPendingPortal(it, this) }
+    detachOwnChildren()
+    hostName = null
+    layoutStateController.resetIfNeeded()
+    layoutStateController.setStateWrapper(null)
+  }
+  // endregion
+
+  // region Host lifecycle callbacks
   internal fun onHostChanged() {
     val host = PortalRegistry.getHost(hostName)
     if (host != null) {
@@ -71,7 +85,7 @@ class PortalView(
         return
       }
       val list = detachOwnChildren()
-      // isTeleported() is now false, so super.addView and addView are equivalent;
+      // isTeleported is now false, so super.addView and addView are equivalent;
       // use super to be explicit that this is a physical re-attach.
       for (i in list.indices) {
         super.addView(list[i], i)
@@ -83,17 +97,9 @@ class PortalView(
   internal fun onHostLayoutChanged() {
     layoutStateController.updateIfNeeded(hostName, PortalRegistry.getHost(hostName))
   }
+  // endregion
 
-  fun cleanup() {
-    hostName?.let { PortalRegistry.unregisterPendingPortal(it, this) }
-    detachOwnChildren()
-    hostName = null
-    layoutStateController.resetIfNeeded()
-    layoutStateController.setStateWrapper(null)
-  }
-
-  private fun isTeleported(): Boolean = hostName != null && PortalRegistry.getHost(hostName) != null
-
+  // region Child relocation helpers
   private fun extractPhysicalChildren(): List<View> {
     // Collect children first, then remove via super.removeView(child).
     // Using super.removeViewAt(i) may call our overridden getChildAt(),
@@ -146,7 +152,7 @@ class PortalView(
 
   private fun extractChildren(): List<View> {
     // Gather current children (logical if teleported, physical otherwise)
-    return if (isTeleported()) detachOwnChildren() else extractPhysicalChildren()
+    return if (isTeleported) detachOwnChildren() else extractPhysicalChildren()
   }
 
   /**
@@ -164,17 +170,18 @@ class PortalView(
     }
     return -1
   }
+  // endregion
 
   // region Children management
   override fun getChildCount(): Int =
-    if (isTeleported()) {
+    if (isTeleported) {
       ownChildren.size
     } else {
       super.getChildCount()
     }
 
   override fun getChildAt(index: Int): View? =
-    if (isTeleported()) {
+    if (isTeleported) {
       ownChildren.getOrNull(index)
     } else {
       super.getChildAt(index)
@@ -184,7 +191,7 @@ class PortalView(
     child: View,
     index: Int,
   ) {
-    if (isTeleported()) {
+    if (isTeleported) {
       val host = PortalRegistry.getHost(hostName)
       ownChildren.add(index, child)
       if (host != null) {
@@ -205,7 +212,7 @@ class PortalView(
     index: Int,
     params: LayoutParams,
   ) {
-    if (isTeleported()) {
+    if (isTeleported) {
       val host = PortalRegistry.getHost(hostName)
       ownChildren.add(index, child)
       if (host != null) {
@@ -223,7 +230,7 @@ class PortalView(
 
   override fun removeView(view: View?) {
     if (view == null) return
-    if (isTeleported()) {
+    if (isTeleported) {
       val host = PortalRegistry.getHost(hostName)
       host?.removeView(view)
       ownChildren.remove(view)
@@ -233,7 +240,7 @@ class PortalView(
   }
 
   override fun removeViewAt(index: Int) {
-    if (isTeleported()) {
+    if (isTeleported) {
       val host = PortalRegistry.getHost(hostName)
       val view = ownChildren.getOrNull(index)
       if (view != null) {
@@ -246,6 +253,7 @@ class PortalView(
   }
   // endregion
 
+  // region Lifecycle
   override fun onLayout(
     changed: Boolean,
     left: Int,
@@ -266,11 +274,12 @@ class PortalView(
     layoutStateController.resetIfNeeded()
     super.onDetachedFromWindow()
   }
+  // endregion
 
   // region Accessibility
   // Override to prevent accessibility from trying to include non-descendant children
   override fun addChildrenForAccessibility(outChildren: ArrayList<View>) {
-    if (!isTeleported()) {
+    if (!isTeleported) {
       super.addChildrenForAccessibility(outChildren)
     }
     // When teleported, do nothing—children are handled by the host's accessibility tree

--- a/android/src/main/java/com/teleport/portal/PortalView.kt
+++ b/android/src/main/java/com/teleport/portal/PortalView.kt
@@ -76,7 +76,6 @@ class PortalView(
         host.addView(children[i], idx)
       }
       ownChildren.addAll(children)
-      layoutStateController.updateIfNeeded(hostName, host)
     } else {
       // Host went away. Pull children back to ourselves so they remain
       // attached to a live view tree and React-driven mutations keep working.

--- a/android/src/main/java/com/teleport/portal/PortalView.kt
+++ b/android/src/main/java/com/teleport/portal/PortalView.kt
@@ -265,15 +265,6 @@ class PortalView(
     layoutStateController.updateIfNeeded(hostName, PortalRegistry.getHost(hostName))
   }
 
-  override fun onAttachedToWindow() {
-    super.onAttachedToWindow()
-    layoutStateController.updateIfNeeded(hostName, PortalRegistry.getHost(hostName))
-  }
-
-  override fun onDetachedFromWindow() {
-    layoutStateController.resetIfNeeded()
-    super.onDetachedFromWindow()
-  }
   // endregion
 
   // region Accessibility

--- a/android/src/main/java/com/teleport/portal/PortalView.kt
+++ b/android/src/main/java/com/teleport/portal/PortalView.kt
@@ -3,26 +3,22 @@ package com.teleport.portal
 import android.content.Context
 import android.view.View
 import android.view.ViewGroup
-import com.facebook.react.bridge.Arguments
-import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.views.view.ReactViewGroup
 import com.teleport.global.PortalRegistry
 import com.teleport.host.PortalHostView
 import java.util.ArrayList
-import kotlin.math.abs
 
 class PortalView(
   context: Context,
 ) : ReactViewGroup(context) {
   private var hostName: String? = null
-  private var lastHostLayout: HostLayoutState? = null
-  private var stateWrapper: StateWrapper? = null
+  private val layoutStateController = PortalLayoutStateController(this)
   private val ownChildren: MutableList<View> = ArrayList()
 
   fun setStateWrapper(wrapper: StateWrapper?) {
-    stateWrapper = wrapper
-    updatePortalLayoutStateIfNeeded()
+    layoutStateController.setStateWrapper(wrapper)
+    layoutStateController.updateIfNeeded(hostName, PortalRegistry.getHost(hostName))
   }
 
   fun setHostName(name: String?) {
@@ -49,7 +45,7 @@ class PortalView(
     }
 
     name?.let { PortalRegistry.registerPendingPortal(it, this) }
-    updatePortalLayoutStateIfNeeded()
+    layoutStateController.updateIfNeeded(hostName, PortalRegistry.getHost(hostName))
   }
 
   internal fun onHostChanged() {
@@ -66,12 +62,12 @@ class PortalView(
         host.addView(children[i], idx)
       }
       ownChildren.addAll(children)
-      updatePortalLayoutStateIfNeeded()
+      layoutStateController.updateIfNeeded(hostName, host)
     } else {
       // Host went away. Pull children back to ourselves so they remain
       // attached to a live view tree and React-driven mutations keep working.
       if (ownChildren.isEmpty()) {
-        resetPortalLayoutStateIfNeeded()
+        layoutStateController.resetIfNeeded()
         return
       }
       val list = detachOwnChildren()
@@ -80,64 +76,23 @@ class PortalView(
       for (i in list.indices) {
         super.addView(list[i], i)
       }
-      resetPortalLayoutStateIfNeeded()
+      layoutStateController.resetIfNeeded()
     }
   }
 
   internal fun onHostLayoutChanged() {
-    updatePortalLayoutStateIfNeeded()
+    layoutStateController.updateIfNeeded(hostName, PortalRegistry.getHost(hostName))
   }
 
   fun cleanup() {
     hostName?.let { PortalRegistry.unregisterPendingPortal(it, this) }
     detachOwnChildren()
     hostName = null
-    resetPortalLayoutStateIfNeeded()
-    stateWrapper = null
+    layoutStateController.resetIfNeeded()
+    layoutStateController.setStateWrapper(null)
   }
 
   private fun isTeleported(): Boolean = hostName != null && PortalRegistry.getHost(hostName) != null
-
-  private fun updatePortalLayoutStateIfNeeded() {
-    val wrapper = stateWrapper ?: return
-    val host = PortalRegistry.getHost(hostName)
-
-    if (hostName == null || host == null || !isAttachedToWindow || !host.isAttachedToWindow) {
-      resetPortalLayoutStateIfNeeded()
-      return
-    }
-
-    if (host.width == 0 || host.height == 0) return
-
-    val sourceLocation = IntArray(2)
-    val hostLocation = IntArray(2)
-    getLocationOnScreen(sourceLocation)
-    host.getLocationOnScreen(hostLocation)
-
-    val nextState =
-      HostLayoutState(
-        width = PixelUtil.toDIPFromPixel(host.width.toFloat()),
-        height = PixelUtil.toDIPFromPixel(host.height.toFloat()),
-        offsetX = PixelUtil.toDIPFromPixel((hostLocation[0] - sourceLocation[0]).toFloat()),
-        offsetY = PixelUtil.toDIPFromPixel((hostLocation[1] - sourceLocation[1]).toFloat()),
-        hasHostLayout = true,
-      )
-
-    if (lastHostLayout?.nearlyEquals(nextState) == true) return
-
-    lastHostLayout = nextState
-    wrapper.updateState(nextState.toMap())
-  }
-
-  private fun resetPortalLayoutStateIfNeeded() {
-    val wrapper = stateWrapper ?: return
-    val currentState = lastHostLayout
-    if (currentState != null && !currentState.hasHostLayout) return
-
-    val nextState = HostLayoutState.EMPTY
-    lastHostLayout = nextState
-    wrapper.updateState(nextState.toMap())
-  }
 
   private fun extractPhysicalChildren(): List<View> {
     // Collect children first, then remove via super.removeView(child).
@@ -299,16 +254,16 @@ class PortalView(
     bottom: Int,
   ) {
     super.onLayout(changed, left, top, right, bottom)
-    updatePortalLayoutStateIfNeeded()
+    layoutStateController.updateIfNeeded(hostName, PortalRegistry.getHost(hostName))
   }
 
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
-    updatePortalLayoutStateIfNeeded()
+    layoutStateController.updateIfNeeded(hostName, PortalRegistry.getHost(hostName))
   }
 
   override fun onDetachedFromWindow() {
-    resetPortalLayoutStateIfNeeded()
+    layoutStateController.resetIfNeeded()
     super.onDetachedFromWindow()
   }
 
@@ -321,43 +276,4 @@ class PortalView(
     // When teleported, do nothing—children are handled by the host's accessibility tree
   }
   // endregion
-
-  private data class HostLayoutState(
-    val width: Float,
-    val height: Float,
-    val offsetX: Float,
-    val offsetY: Float,
-    val hasHostLayout: Boolean,
-  ) {
-    fun nearlyEquals(other: HostLayoutState): Boolean =
-      hasHostLayout == other.hasHostLayout &&
-        abs(width - other.width) < STATE_EPSILON &&
-        abs(height - other.height) < STATE_EPSILON &&
-        abs(offsetX - other.offsetX) < STATE_EPSILON &&
-        abs(offsetY - other.offsetY) < STATE_EPSILON
-
-    fun toMap() =
-      Arguments.createMap().apply {
-        putDouble("width", width.toDouble())
-        putDouble("height", height.toDouble())
-        putDouble("offsetX", offsetX.toDouble())
-        putDouble("offsetY", offsetY.toDouble())
-        putBoolean("hasHostLayout", hasHostLayout)
-      }
-
-    companion object {
-      val EMPTY =
-        HostLayoutState(
-          width = 0f,
-          height = 0f,
-          offsetX = 0f,
-          offsetY = 0f,
-          hasHostLayout = false,
-        )
-    }
-  }
-
-  companion object {
-    private const val STATE_EPSILON = 0.01f
-  }
 }

--- a/android/src/main/java/com/teleport/portal/PortalView.kt
+++ b/android/src/main/java/com/teleport/portal/PortalView.kt
@@ -3,16 +3,27 @@ package com.teleport.portal
 import android.content.Context
 import android.view.View
 import android.view.ViewGroup
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.uimanager.PixelUtil
+import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.views.view.ReactViewGroup
 import com.teleport.global.PortalRegistry
 import com.teleport.host.PortalHostView
 import java.util.ArrayList
+import kotlin.math.abs
 
 class PortalView(
   context: Context,
 ) : ReactViewGroup(context) {
   private var hostName: String? = null
+  private var lastHostLayout: HostLayoutState? = null
+  private var stateWrapper: StateWrapper? = null
   private val ownChildren: MutableList<View> = ArrayList()
+
+  fun setStateWrapper(wrapper: StateWrapper?) {
+    stateWrapper = wrapper
+    updatePortalLayoutStateIfNeeded()
+  }
 
   fun setHostName(name: String?) {
     if (name == hostName) return
@@ -38,6 +49,7 @@ class PortalView(
     }
 
     name?.let { PortalRegistry.registerPendingPortal(it, this) }
+    updatePortalLayoutStateIfNeeded()
   }
 
   internal fun onHostChanged() {
@@ -54,26 +66,78 @@ class PortalView(
         host.addView(children[i], idx)
       }
       ownChildren.addAll(children)
+      updatePortalLayoutStateIfNeeded()
     } else {
       // Host went away. Pull children back to ourselves so they remain
       // attached to a live view tree and React-driven mutations keep working.
-      if (ownChildren.isEmpty()) return
+      if (ownChildren.isEmpty()) {
+        resetPortalLayoutStateIfNeeded()
+        return
+      }
       val list = detachOwnChildren()
       // isTeleported() is now false, so super.addView and addView are equivalent;
       // use super to be explicit that this is a physical re-attach.
       for (i in list.indices) {
         super.addView(list[i], i)
       }
+      resetPortalLayoutStateIfNeeded()
     }
+  }
+
+  internal fun onHostLayoutChanged() {
+    updatePortalLayoutStateIfNeeded()
   }
 
   fun cleanup() {
     hostName?.let { PortalRegistry.unregisterPendingPortal(it, this) }
     detachOwnChildren()
     hostName = null
+    resetPortalLayoutStateIfNeeded()
+    stateWrapper = null
   }
 
   private fun isTeleported(): Boolean = hostName != null && PortalRegistry.getHost(hostName) != null
+
+  private fun updatePortalLayoutStateIfNeeded() {
+    val wrapper = stateWrapper ?: return
+    val host = PortalRegistry.getHost(hostName)
+
+    if (hostName == null || host == null || !isAttachedToWindow || !host.isAttachedToWindow) {
+      resetPortalLayoutStateIfNeeded()
+      return
+    }
+
+    if (host.width == 0 || host.height == 0) return
+
+    val sourceLocation = IntArray(2)
+    val hostLocation = IntArray(2)
+    getLocationOnScreen(sourceLocation)
+    host.getLocationOnScreen(hostLocation)
+
+    val nextState =
+      HostLayoutState(
+        width = PixelUtil.toDIPFromPixel(host.width.toFloat()),
+        height = PixelUtil.toDIPFromPixel(host.height.toFloat()),
+        offsetX = PixelUtil.toDIPFromPixel((hostLocation[0] - sourceLocation[0]).toFloat()),
+        offsetY = PixelUtil.toDIPFromPixel((hostLocation[1] - sourceLocation[1]).toFloat()),
+        hasHostLayout = true,
+      )
+
+    if (lastHostLayout?.nearlyEquals(nextState) == true) return
+
+    lastHostLayout = nextState
+    wrapper.updateState(nextState.toMap())
+  }
+
+  private fun resetPortalLayoutStateIfNeeded() {
+    val wrapper = stateWrapper ?: return
+    val currentState = lastHostLayout
+    if (currentState != null && !currentState.hasHostLayout) return
+
+    val nextState = HostLayoutState.EMPTY
+    lastHostLayout = nextState
+    wrapper.updateState(nextState.toMap())
+  }
 
   private fun extractPhysicalChildren(): List<View> {
     // Collect children first, then remove via super.removeView(child).
@@ -227,6 +291,27 @@ class PortalView(
   }
   // endregion
 
+  override fun onLayout(
+    changed: Boolean,
+    left: Int,
+    top: Int,
+    right: Int,
+    bottom: Int,
+  ) {
+    super.onLayout(changed, left, top, right, bottom)
+    updatePortalLayoutStateIfNeeded()
+  }
+
+  override fun onAttachedToWindow() {
+    super.onAttachedToWindow()
+    updatePortalLayoutStateIfNeeded()
+  }
+
+  override fun onDetachedFromWindow() {
+    resetPortalLayoutStateIfNeeded()
+    super.onDetachedFromWindow()
+  }
+
   // region Accessibility
   // Override to prevent accessibility from trying to include non-descendant children
   override fun addChildrenForAccessibility(outChildren: ArrayList<View>) {
@@ -236,4 +321,43 @@ class PortalView(
     // When teleported, do nothing—children are handled by the host's accessibility tree
   }
   // endregion
+
+  private data class HostLayoutState(
+    val width: Float,
+    val height: Float,
+    val offsetX: Float,
+    val offsetY: Float,
+    val hasHostLayout: Boolean,
+  ) {
+    fun nearlyEquals(other: HostLayoutState): Boolean =
+      hasHostLayout == other.hasHostLayout &&
+        abs(width - other.width) < STATE_EPSILON &&
+        abs(height - other.height) < STATE_EPSILON &&
+        abs(offsetX - other.offsetX) < STATE_EPSILON &&
+        abs(offsetY - other.offsetY) < STATE_EPSILON
+
+    fun toMap() =
+      Arguments.createMap().apply {
+        putDouble("width", width.toDouble())
+        putDouble("height", height.toDouble())
+        putDouble("offsetX", offsetX.toDouble())
+        putDouble("offsetY", offsetY.toDouble())
+        putBoolean("hasHostLayout", hasHostLayout)
+      }
+
+    companion object {
+      val EMPTY =
+        HostLayoutState(
+          width = 0f,
+          height = 0f,
+          offsetX = 0f,
+          offsetY = 0f,
+          hasHostLayout = false,
+        )
+    }
+  }
+
+  companion object {
+    private const val STATE_EPSILON = 0.01f
+  }
 }

--- a/android/src/main/java/com/teleport/portal/PortalViewManager.kt
+++ b/android/src/main/java/com/teleport/portal/PortalViewManager.kt
@@ -1,6 +1,8 @@
 package com.teleport.portal
 
 import com.facebook.react.module.annotations.ReactModule
+import com.facebook.react.uimanager.ReactStylesDiffMap
+import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.ViewManagerDelegate
 import com.facebook.react.uimanager.annotations.ReactProp
@@ -24,6 +26,15 @@ class PortalViewManager :
   override fun onDropViewInstance(view: ReactViewGroup) {
     (view as? PortalView)?.cleanup()
     super.onDropViewInstance(view)
+  }
+
+  override fun updateState(
+    view: ReactViewGroup,
+    props: ReactStylesDiffMap?,
+    stateWrapper: StateWrapper?,
+  ): Any? {
+    (view as? PortalView)?.setStateWrapper(stateWrapper)
+    return super.updateState(view, props, stateWrapper)
   }
 
   @ReactProp(name = "name")

--- a/common/cpp/react/renderer/components/TeleportViewSpec/RNTPortalViewComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/TeleportViewSpec/RNTPortalViewComponentDescriptor.h
@@ -30,8 +30,7 @@ namespace facebook::react {
         // - we need to stretch the view beyond the parent layout constraints
         yogaPortal.setPositionType(YGPositionTypeAbsolute);
 
-        HostSize hostSize =
-            PortalShadowRegistry::getInstance().getHostSize(props.hostName);
+        HostSize hostSize = PortalShadowRegistry::getInstance().getHostSize(props.hostName);
         portalViewShadowNode.setDimensionsFromHost(hostSize);
       }
 

--- a/common/cpp/react/renderer/components/TeleportViewSpec/RNTPortalViewComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/TeleportViewSpec/RNTPortalViewComponentDescriptor.h
@@ -30,9 +30,16 @@ namespace facebook::react {
         // - we need to stretch the view beyond the parent layout constraints
         yogaPortal.setPositionType(YGPositionTypeAbsolute);
 
-        HostSize hostSize = PortalShadowRegistry::getInstance().getHostSize(props.hostName);
-
-        portalViewShadowNode.setDimensionsFromHost(hostSize);
+        auto &stateData = static_cast<const PortalViewShadowNode::ConcreteState &>(
+                              *portalViewShadowNode.getState())
+                              .getData();
+        if (stateData.hasHostLayout) {
+          portalViewShadowNode.setDimensionsFromState(stateData);
+        } else {
+          HostSize hostSize =
+              PortalShadowRegistry::getInstance().getHostSize(props.hostName);
+          portalViewShadowNode.setDimensionsFromHost(hostSize);
+        }
       }
 
       ConcreteComponentDescriptor::adopt(shadowNode);

--- a/common/cpp/react/renderer/components/TeleportViewSpec/RNTPortalViewComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/TeleportViewSpec/RNTPortalViewComponentDescriptor.h
@@ -31,6 +31,7 @@ namespace facebook::react {
         yogaPortal.setPositionType(YGPositionTypeAbsolute);
 
         HostSize hostSize = PortalShadowRegistry::getInstance().getHostSize(props.hostName);
+
         portalViewShadowNode.setDimensionsFromHost(hostSize);
       }
 

--- a/common/cpp/react/renderer/components/TeleportViewSpec/RNTPortalViewComponentDescriptor.h
+++ b/common/cpp/react/renderer/components/TeleportViewSpec/RNTPortalViewComponentDescriptor.h
@@ -30,16 +30,9 @@ namespace facebook::react {
         // - we need to stretch the view beyond the parent layout constraints
         yogaPortal.setPositionType(YGPositionTypeAbsolute);
 
-        auto &stateData = static_cast<const PortalViewShadowNode::ConcreteState &>(
-                              *portalViewShadowNode.getState())
-                              .getData();
-        if (stateData.hasHostLayout) {
-          portalViewShadowNode.setDimensionsFromState(stateData);
-        } else {
-          HostSize hostSize =
-              PortalShadowRegistry::getInstance().getHostSize(props.hostName);
-          portalViewShadowNode.setDimensionsFromHost(hostSize);
-        }
+        HostSize hostSize =
+            PortalShadowRegistry::getInstance().getHostSize(props.hostName);
+        portalViewShadowNode.setDimensionsFromHost(hostSize);
       }
 
       ConcreteComponentDescriptor::adopt(shadowNode);

--- a/common/cpp/react/renderer/components/TeleportViewSpec/RNTPortalViewShadowNode.h
+++ b/common/cpp/react/renderer/components/TeleportViewSpec/RNTPortalViewShadowNode.h
@@ -33,21 +33,16 @@ namespace facebook::react {
       }
     }
 
-    void setDimensionsFromState(PortalViewState state) const {
-      if (state.hasHostLayout && state.width != 0 && state.height != 0) {
-        setSize(Size(state.width, state.height));
-      }
-    }
-
     Transform getTransform() const override {
       auto transform = ConcreteViewShadowNode::getTransform();
+      auto &props = static_cast<const PortalViewProps &>(*getProps());
+      if (props.hostName.empty()) {
+        return transform;
+      }
+
       const auto &stateData =
           static_cast<const PortalViewShadowNode::ConcreteState &>(*getState())
               .getData();
-
-      if (!stateData.hasHostLayout) {
-        return transform;
-      }
 
       return transform * Transform::Translate(stateData.offsetX, stateData.offsetY, 0);
     }

--- a/common/cpp/react/renderer/components/TeleportViewSpec/RNTPortalViewShadowNode.h
+++ b/common/cpp/react/renderer/components/TeleportViewSpec/RNTPortalViewShadowNode.h
@@ -6,6 +6,7 @@
 #include <react/renderer/components/TeleportViewSpec/EventEmitters.h>
 #include <react/renderer/components/TeleportViewSpec/Props.h>
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
+#include <react/renderer/graphics/Transform.h>
 #include <jsi/jsi.h>
 
 namespace facebook::react {
@@ -30,6 +31,25 @@ namespace facebook::react {
       if (hostSize.width != 0 && hostSize.height != 0) {
         setSize(Size(hostSize.width, hostSize.height));
       }
+    }
+
+    void setDimensionsFromState(PortalViewState state) const {
+      if (state.hasHostLayout && state.width != 0 && state.height != 0) {
+        setSize(Size(state.width, state.height));
+      }
+    }
+
+    Transform getTransform() const override {
+      auto transform = ConcreteViewShadowNode::getTransform();
+      const auto &stateData =
+          static_cast<const PortalViewShadowNode::ConcreteState &>(*getState())
+              .getData();
+
+      if (!stateData.hasHostLayout) {
+        return transform;
+      }
+
+      return transform * Transform::Translate(stateData.offsetX, stateData.offsetY, 0);
     }
   };
 

--- a/common/cpp/react/renderer/components/TeleportViewSpec/RNTPortalViewState.h
+++ b/common/cpp/react/renderer/components/TeleportViewSpec/RNTPortalViewState.h
@@ -12,36 +12,22 @@ namespace facebook::react {
    public:
     PortalViewState() = default;
     PortalViewState(
-        Float width_,
-        Float height_,
         Float offsetX_,
         Float offsetY_)
-        : width(width_),
-          height(height_),
-          offsetX(offsetX_),
-          offsetY(offsetY_),
-          hasHostLayout(true) {}
+        : offsetX(offsetX_), offsetY(offsetY_) {}
 
 #ifdef ANDROID
     PortalViewState(PortalViewState const &previousState, folly::dynamic data)
-        : width((Float)data["width"].getDouble()),
-          height((Float)data["height"].getDouble()),
-          offsetX((Float)data["offsetX"].getDouble()),
-          offsetY((Float)data["offsetY"].getDouble()),
-          hasHostLayout(data["hasHostLayout"].getBool()) {}
+        : offsetX((Float)data["offsetX"].getDouble()),
+          offsetY((Float)data["offsetY"].getDouble()) {}
 
     folly::dynamic getDynamic() const {
-      return folly::dynamic::object("width", width)("height", height)(
-          "offsetX", offsetX)("offsetY", offsetY)(
-          "hasHostLayout", hasHostLayout);
+      return folly::dynamic::object("offsetX", offsetX)("offsetY", offsetY);
     }
 #endif
 
-    Float width{0};
-    Float height{0};
     Float offsetX{0};
     Float offsetY{0};
-    bool hasHostLayout{false};
   };
 
 } // namespace facebook::react

--- a/common/cpp/react/renderer/components/TeleportViewSpec/RNTPortalViewState.h
+++ b/common/cpp/react/renderer/components/TeleportViewSpec/RNTPortalViewState.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <react/renderer/graphics/Float.h>
+
 #ifdef ANDROID
 #include <folly/dynamic.h>
 #endif
@@ -9,13 +11,37 @@ namespace facebook::react {
   class PortalViewState {
    public:
     PortalViewState() = default;
+    PortalViewState(
+        Float width_,
+        Float height_,
+        Float offsetX_,
+        Float offsetY_)
+        : width(width_),
+          height(height_),
+          offsetX(offsetX_),
+          offsetY(offsetY_),
+          hasHostLayout(true) {}
 
 #ifdef ANDROID
-    PortalViewState(PortalViewState const &previousState, folly::dynamic data) {}
+    PortalViewState(PortalViewState const &previousState, folly::dynamic data)
+        : width((Float)data["width"].getDouble()),
+          height((Float)data["height"].getDouble()),
+          offsetX((Float)data["offsetX"].getDouble()),
+          offsetY((Float)data["offsetY"].getDouble()),
+          hasHostLayout(data["hasHostLayout"].getBool()) {}
+
     folly::dynamic getDynamic() const {
-      return {};
+      return folly::dynamic::object("width", width)("height", height)(
+          "offsetX", offsetX)("offsetY", offsetY)(
+          "hasHostLayout", hasHostLayout);
     }
 #endif
+
+    Float width{0};
+    Float height{0};
+    Float offsetX{0};
+    Float offsetY{0};
+    bool hasHostLayout{false};
   };
 
 } // namespace facebook::react

--- a/ios/PortalHostView.mm
+++ b/ios/PortalHostView.mm
@@ -62,6 +62,15 @@ using namespace facebook::react;
   [super updateProps:props oldProps:oldProps];
 }
 
+- (void)layoutSubviews
+{
+  [super layoutSubviews];
+
+  if (self.registeredName) {
+    [[PortalRegistry sharedInstance] notifyHostLayoutChangedWithName:self.registeredName];
+  }
+}
+
 - (NSInteger)nextInsertionIndexForChildAt:(NSInteger)childIndex
 {
   if (!self.isInBatch) {

--- a/ios/PortalRegistry.h
+++ b/ios/PortalRegistry.h
@@ -20,6 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)registerHost:(PortalHostView *)host withName:(NSString *)name;
 - (void)unregisterHostWithName:(NSString *)name viewTag:(NSInteger)viewTag;
 - (nullable PortalHostView *)getHostWithName:(NSString *)name;
+- (void)notifyHostLayoutChangedWithName:(NSString *)name;
 
 - (void)registerPendingPortal:(PortalView *)portal withHostName:(NSString *)hostName;
 - (void)unregisterPendingPortal:(PortalView *)portal withHostName:(NSString *)hostName;

--- a/ios/PortalRegistry.mm
+++ b/ios/PortalRegistry.mm
@@ -81,6 +81,15 @@
   return [self.hosts objectForKey:name];
 }
 
+- (void)notifyHostLayoutChangedWithName:(NSString *)name
+{
+  if (!name) {
+    return;
+  }
+
+  [self notifySubscribersForName:name];
+}
+
 - (void)registerPendingPortal:(PortalView *)portal withHostName:(NSString *)hostName
 {
   if (!hostName || !portal) {

--- a/ios/PortalRegistry.mm
+++ b/ios/PortalRegistry.mm
@@ -87,7 +87,19 @@
     return;
   }
 
-  [self notifySubscribersForName:name];
+  NSPointerArray *portals = self.pendingPortals[name];
+  if (!portals) {
+    return;
+  }
+
+  [portals compact];
+
+  for (NSUInteger i = 0; i < portals.count; i++) {
+    PortalView *portal = (__bridge PortalView *)[portals pointerAtIndex:i];
+    if (portal) {
+      [portal onHostLayoutChanged];
+    }
+  }
 }
 
 - (void)registerPendingPortal:(PortalView *)portal withHostName:(NSString *)hostName

--- a/ios/PortalView.h
+++ b/ios/PortalView.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PortalView : RCTViewComponentView
 
 - (void)onHostChanged;
+- (void)onHostLayoutChanged;
 
 @end
 

--- a/ios/PortalView.mm
+++ b/ios/PortalView.mm
@@ -19,14 +19,7 @@
 
 #import <React/RCTSurfaceTouchHandler.h>
 
-#include <cmath>
-
 using namespace facebook::react;
-
-static bool RNTNearlyEqual(Float lhs, Float rhs)
-{
-  return std::abs(lhs - rhs) < 0.01;
-}
 
 @interface PortalView () <RCTPortalViewViewProtocol>
 
@@ -79,7 +72,7 @@ static bool RNTNearlyEqual(Float lhs, Float rhs)
   _state->updateState(
       [=](const PortalViewShadowNode::ConcreteState::Data &oldData)
           -> PortalViewShadowNode::ConcreteState::SharedData {
-        if (!oldData.hasHostLayout) {
+        if (oldData.offsetX == newData.offsetX && oldData.offsetY == newData.offsetY) {
           return nullptr;
         }
 
@@ -101,8 +94,7 @@ static bool RNTNearlyEqual(Float lhs, Float rhs)
   CGRect sourceRect = [self screenRectForView:self];
   CGRect hostRect = [self screenRectForView:self.targetView];
 
-  if (CGRectIsNull(sourceRect) || CGRectIsNull(hostRect) || hostRect.size.width == 0 ||
-      hostRect.size.height == 0) {
+  if (CGRectIsNull(sourceRect) || CGRectIsNull(hostRect)) {
     return;
   }
 
@@ -110,18 +102,13 @@ static bool RNTNearlyEqual(Float lhs, Float rhs)
   // PortalView shadow node. Store the host-source delta so Fabric measurement
   // follows the native destination.
   PortalViewState newData = {
-      static_cast<Float>(hostRect.size.width),
-      static_cast<Float>(hostRect.size.height),
       static_cast<Float>(hostRect.origin.x - sourceRect.origin.x),
       static_cast<Float>(hostRect.origin.y - sourceRect.origin.y)};
 
   _state->updateState(
       [=](const PortalViewShadowNode::ConcreteState::Data &oldData)
           -> PortalViewShadowNode::ConcreteState::SharedData {
-        if (oldData.hasHostLayout && RNTNearlyEqual(oldData.width, newData.width) &&
-            RNTNearlyEqual(oldData.height, newData.height) &&
-            RNTNearlyEqual(oldData.offsetX, newData.offsetX) &&
-            RNTNearlyEqual(oldData.offsetY, newData.offsetY)) {
+        if (oldData.offsetX == newData.offsetX && oldData.offsetY == newData.offsetY) {
           return nullptr;
         }
 

--- a/ios/PortalView.mm
+++ b/ios/PortalView.mm
@@ -206,8 +206,6 @@ using namespace facebook::react;
       [self.targetView addSubview:childComponentView];
     }
   }
-
-  [self updatePortalLayoutStateIfNeeded];
 }
 
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView

--- a/ios/PortalView.mm
+++ b/ios/PortalView.mm
@@ -134,8 +134,6 @@ using namespace facebook::react;
       [target addSubview:child];
     }
   }
-
-  [self updatePortalLayoutStateIfNeeded];
 }
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
@@ -229,6 +227,13 @@ using namespace facebook::react;
     [self moveOwnChildrenToTarget:newTarget];
   }
 
+  if (!hostView) {
+    [self resetPortalLayoutStateIfNeeded];
+  }
+}
+
+- (void)onHostLayoutChanged
+{
   [self updatePortalLayoutStateIfNeeded];
 }
 

--- a/ios/PortalView.mm
+++ b/ios/PortalView.mm
@@ -238,18 +238,6 @@ using namespace facebook::react;
   [self updatePortalLayoutStateIfNeeded];
 }
 
-- (void)didMoveToWindow
-{
-  [super didMoveToWindow];
-  [self updatePortalLayoutStateIfNeeded];
-}
-
-- (void)finalizeUpdates:(RNComponentViewUpdateMask)updateMask
-{
-  [super finalizeUpdates:updateMask];
-  [self updatePortalLayoutStateIfNeeded];
-}
-
 - (void)updateState:(const facebook::react::State::Shared &)state
            oldState:(const facebook::react::State::Shared &)oldState
 {

--- a/ios/PortalView.mm
+++ b/ios/PortalView.mm
@@ -13,12 +13,20 @@
 #import <react/renderer/components/TeleportViewSpec/Props.h>
 #import <react/renderer/components/TeleportViewSpec/RCTComponentViewHelpers.h>
 #import <react/renderer/components/TeleportViewSpec/RNTPortalViewComponentDescriptor.h>
+#import <react/renderer/components/TeleportViewSpec/RNTPortalViewShadowNode.h>
 
 #import "RCTFabricComponentsPlugins.h"
 
 #import <React/RCTSurfaceTouchHandler.h>
 
+#include <cmath>
+
 using namespace facebook::react;
+
+static bool RNTNearlyEqual(Float lhs, Float rhs)
+{
+  return std::abs(lhs - rhs) < 0.01;
+}
 
 @interface PortalView () <RCTPortalViewViewProtocol>
 
@@ -29,6 +37,7 @@ using namespace facebook::react;
 
 @implementation PortalView {
   NSMutableArray<UIView *> *_ownChildren;
+  PortalViewShadowNode::ConcreteState::Shared _state;
 }
 
 + (ComponentDescriptorProvider)componentDescriptorProvider
@@ -51,6 +60,75 @@ using namespace facebook::react;
   return self;
 }
 
+- (CGRect)screenRectForView:(UIView *)view
+{
+  if (!view.window) {
+    return CGRectNull;
+  }
+
+  return [view convertRect:view.bounds toCoordinateSpace:view.window.screen.coordinateSpace];
+}
+
+- (void)resetPortalLayoutStateIfNeeded
+{
+  if (!_state) {
+    return;
+  }
+
+  PortalViewState newData = {};
+  _state->updateState(
+      [=](const PortalViewShadowNode::ConcreteState::Data &oldData)
+          -> PortalViewShadowNode::ConcreteState::SharedData {
+        if (!oldData.hasHostLayout) {
+          return nullptr;
+        }
+
+        return std::make_shared<const PortalViewShadowNode::ConcreteState::Data>(newData);
+      });
+}
+
+- (void)updatePortalLayoutStateIfNeeded
+{
+  if (!_state) {
+    return;
+  }
+
+  if (!self.hostName || ![self.targetView isKindOfClass:[PortalHostView class]]) {
+    [self resetPortalLayoutStateIfNeeded];
+    return;
+  }
+
+  CGRect sourceRect = [self screenRectForView:self];
+  CGRect hostRect = [self screenRectForView:self.targetView];
+
+  if (CGRectIsNull(sourceRect) || CGRectIsNull(hostRect) || hostRect.size.width == 0 ||
+      hostRect.size.height == 0) {
+    return;
+  }
+
+  // Children are physically mounted under the host, but measured through this
+  // PortalView shadow node. Store the host-source delta so Fabric measurement
+  // follows the native destination.
+  PortalViewState newData = {
+      static_cast<Float>(hostRect.size.width),
+      static_cast<Float>(hostRect.size.height),
+      static_cast<Float>(hostRect.origin.x - sourceRect.origin.x),
+      static_cast<Float>(hostRect.origin.y - sourceRect.origin.y)};
+
+  _state->updateState(
+      [=](const PortalViewShadowNode::ConcreteState::Data &oldData)
+          -> PortalViewShadowNode::ConcreteState::SharedData {
+        if (oldData.hasHostLayout && RNTNearlyEqual(oldData.width, newData.width) &&
+            RNTNearlyEqual(oldData.height, newData.height) &&
+            RNTNearlyEqual(oldData.offsetX, newData.offsetX) &&
+            RNTNearlyEqual(oldData.offsetY, newData.offsetY)) {
+          return nullptr;
+        }
+
+        return std::make_shared<const PortalViewShadowNode::ConcreteState::Data>(newData);
+      });
+}
+
 - (void)moveOwnChildrenToTarget:(UIView *)target
 {
   NSArray<UIView *> *children = [_ownChildren copy];
@@ -69,6 +147,8 @@ using namespace facebook::react;
       [target addSubview:child];
     }
   }
+
+  [self updatePortalLayoutStateIfNeeded];
 }
 
 - (void)updateProps:(Props::Shared const &)props oldProps:(Props::Shared const &)oldProps
@@ -107,6 +187,7 @@ using namespace facebook::react;
   }
 
   [super updateProps:props oldProps:oldProps];
+  [self updatePortalLayoutStateIfNeeded];
 }
 
 /// Finds the host index of the first next sibling (in _ownChildren) that is
@@ -140,6 +221,8 @@ using namespace facebook::react;
       [self.targetView addSubview:childComponentView];
     }
   }
+
+  [self updatePortalLayoutStateIfNeeded];
 }
 
 - (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView
@@ -158,6 +241,33 @@ using namespace facebook::react;
     self.targetView = newTarget;
     [self moveOwnChildrenToTarget:newTarget];
   }
+
+  [self updatePortalLayoutStateIfNeeded];
+}
+
+- (void)layoutSubviews
+{
+  [super layoutSubviews];
+  [self updatePortalLayoutStateIfNeeded];
+}
+
+- (void)didMoveToWindow
+{
+  [super didMoveToWindow];
+  [self updatePortalLayoutStateIfNeeded];
+}
+
+- (void)finalizeUpdates:(RNComponentViewUpdateMask)updateMask
+{
+  [super finalizeUpdates:updateMask];
+  [self updatePortalLayoutStateIfNeeded];
+}
+
+- (void)updateState:(const facebook::react::State::Shared &)state
+           oldState:(const facebook::react::State::Shared &)oldState
+{
+  _state = std::static_pointer_cast<const PortalViewShadowNode::ConcreteState>(state);
+  [self updatePortalLayoutStateIfNeeded];
 }
 
 - (void)prepareForRecycle
@@ -175,6 +285,7 @@ using namespace facebook::react;
   self.hostName = nil;
   self.targetView = self.contentView;
   [_ownChildren removeAllObjects];
+  _state.reset();
 }
 
 // MARK: touch handling


### PR DESCRIPTION
## 📜 Description

Fixed a problem with non-firing `onPress` handlers when `Portal` is teleported to another place.

## 💡 Motivation and Context

Teleport renders children in a different native location than where the corresponding `PortalView` exists in the React/Fabric tree. Visually and natively the button is mounted under the **destination** host, but Fabric measurement still resolves through the **original** shadow-node position.

This breaks press handling in cases where `Pressability` revalidates the press region after a _**move**_ event. The touch can start correctly and show visual feedback, but after a small finger movement `Pressability` calls `measure`, receives a responder rect from the **original** tree position, decides the touch is **outside** of the press rect, and **rejects** `onPress`. This is why the issue is visible with real finger movement and with layouts where the visual/native destination is offset from the original JSX position, for example when a navigation header shifts the screen content.

The root cause is not Pressable itself. Pressable is doing the expected responder-region check. The problem is that the teleported native view and the measured Fabric/shadow-tree position are **out of sync.**

The **correct** fix is to make Fabric measurement follow the native destination. We keep host size owned by the shadow tree, and publish only the native source-to-host offset into `PortalViewState`. `RNTPortalViewShadowNode` then applies this offset through `getTransform`, so `measure` sees the portal at the same place where the native children are actually rendered.

We achieve this by notifying portals when host layout changes, calculating the source/host screen delta on each platform, storing it as `offsetX`/`offsetY`, and applying that offset in the portal shadow node transform.

> The one possible alternative could be implementing custom Fabric measurement - but this is much more complex than needed because transform already participates in measurement.

Closes https://github.com/kirillzyusko/react-native-teleport/issues/148

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### C++

- added `offsetX`/`offsetY` to `PortalViewState`;
- override `getTransform` in `RNTPortalViewShadowNode` (so that `measure` will pick up correct values);

### iOS

- added `notifyHostLayoutChangedWithName` to `PortalRegistry`;
- added `onHostLayoutChanged` to `PortalView`;
- override `layoutSubviews` in `PortalHostView` and notify portals when host layout changes;
- store `PortalViewState` in `PortalView`;
- calculate source/host screen rect delta and publish it as `offsetX`/`offsetY`;
- reset portal layout state when host is missing;
- update portal layout state from `layoutSubviews`, `onHostLayoutChanged`, `updateState`, and `updateProps`;

### Android

- added `notifyHostLayoutChanged` to `PortalRegistry`;
- added `View` extension (`isDetached`/`screenLocation`);
- added `Float` extension (`dp`/`px`);
- override `onLayout` in `PortalHostView` and notify portals via `notifyHostLayoutChanged`;
- make `isTeleported` getter;
- added `PortalLayoutStateController`;
- set `StateWrapper` from `PortalViewManager`;
- calculate source/host screen delta and publish it as `offsetX`/`offsetY`;
- update/reset portal layout state from `PortalView` host/layout lifecycle callbacks;

## 🤔 How Has This Been Tested?

Tested on:
- iPhone 16 Pro (iOS 26.2, simulator);
- Pixel 9 Pro (API 35, emulator);
- Pixel 7 Pro (API 36, real device);

## 📸 Screenshots (if appropriate):

### iOS

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/e3b74e61-e3c5-4e1f-8a44-de0751acb570">|<video src="https://github.com/user-attachments/assets/153a773d-d5e3-47b5-b762-0e92bcf996c6">|

### Android

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/74cab854-fc83-4c3e-954a-a09f1bdbc389">|<video src="https://github.com/user-attachments/assets/7a9d009b-eb8d-4349-a972-c9c53dba141f">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
