### PR TITLE
e2e: improve iOS stability tests on CI

### DIFF
--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -140,6 +140,11 @@ jobs:
           xcrun simctl bootstatus "$UDID"
           osascript -e 'tell application "Simulator" to activate'
           xcrun simctl install "$UDID" example/ios/build/Build/Products/Release-iphonesimulator/TeleportExample.app
+      - name: Record simulator video
+        run: |
+          mkdir -p e2e/reports/videos
+          xcrun simctl io booted recordVideo e2e/reports/videos/dynamic-children.mp4 &
+          echo $! > /tmp/sim-video.pid
       - name: Run E2E tests
         run: |
           node e2e/snapshot-engine.js &
@@ -147,6 +152,11 @@ jobs:
           export MAESTRO_DRIVER_STARTUP_TIMEOUT=600000
           maestro --platform ios test -e DEVICE="iPhone 16 Pro" e2e/flows/* --format html ./e2e/reports/debug --debug-output ./e2e/reports/debug --flatten-debug-output
           kill $SERVER_PID
+      - name: Stop video recording
+        if: always()
+        run: |
+          kill -INT $(cat /tmp/sim-video.pid) || true
+          sleep 2
       - name: Upload test report
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -126,13 +126,6 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
-      - name: Install Maestro CLI
-        run: |
-          brew tap mobile-dev-inc/tap
-          brew install mobile-dev-inc/tap/maestro
-      - name: Prepare snapshot engine
-        run: cd e2e && npm install
-
       - name: Install app on simulator
         run: |
           UDID=$(xcrun simctl list devices | grep "iPhone 16 Pro (" | grep -oE "[0-9A-F-]{36}" | head -n 1)
@@ -140,6 +133,12 @@ jobs:
           xcrun simctl bootstatus "$UDID"
           osascript -e 'tell application "Simulator" to activate'
           xcrun simctl install "$UDID" example/ios/build/Build/Products/Release-iphonesimulator/TeleportExample.app
+      - name: Install Maestro CLI
+        run: |
+          brew tap mobile-dev-inc/tap
+          brew install mobile-dev-inc/tap/maestro
+      - name: Prepare snapshot engine
+        run: cd e2e && npm install
       - name: Record simulator video
         run: |
           mkdir -p e2e/reports/videos

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -157,6 +157,18 @@ jobs:
         run: |
           kill -INT $(cat /tmp/sim-video.pid) || true
           sleep 2
+      - name: Collect focused logs
+        if: always()
+        run: |
+          mkdir -p e2e/reports/system
+
+          xcrun simctl spawn booted log show \
+            --style compact \
+            --last 10m \
+            --predicate 'process == "teleport" OR process == "teleport.example" OR eventMessage CONTAINS "teleport.example" OR eventMessage CONTAINS "Terminating app" OR eventMessage CONTAINS "crash" OR eventMessage CONTAINS "JetsamEvent"' \
+            > e2e/reports/system/teleport.log || true
+
+          cp -R ~/Library/Logs/DiagnosticReports e2e/reports/system/DiagnosticReports || true
       - name: Upload test report
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -139,11 +139,6 @@ jobs:
           brew install mobile-dev-inc/tap/maestro
       - name: Prepare snapshot engine
         run: cd e2e && npm install
-      - name: Record simulator video
-        run: |
-          mkdir -p e2e/reports/videos
-          xcrun simctl io booted recordVideo e2e/reports/videos/dynamic-children.mp4 &
-          echo $! > /tmp/sim-video.pid
       - name: Run E2E tests
         run: |
           node e2e/snapshot-engine.js &
@@ -151,23 +146,6 @@ jobs:
           export MAESTRO_DRIVER_STARTUP_TIMEOUT=600000
           maestro --platform ios test -e DEVICE="iPhone 16 Pro" e2e/flows/* --format html ./e2e/reports/debug --debug-output ./e2e/reports/debug --flatten-debug-output
           kill $SERVER_PID
-      - name: Stop video recording
-        if: always()
-        run: |
-          kill -INT $(cat /tmp/sim-video.pid) || true
-          sleep 2
-      - name: Collect focused logs
-        if: always()
-        run: |
-          mkdir -p e2e/reports/system
-
-          xcrun simctl spawn booted log show \
-            --style compact \
-            --last 10m \
-            --predicate 'process == "teleport" OR process == "teleport.example" OR eventMessage CONTAINS "teleport.example" OR eventMessage CONTAINS "Terminating app" OR eventMessage CONTAINS "crash" OR eventMessage CONTAINS "JetsamEvent"' \
-            > e2e/reports/system/teleport.log || true
-
-          cp -R ~/Library/Logs/DiagnosticReports e2e/reports/system/DiagnosticReports || true
       - name: Upload test report
         if: failure()
         uses: actions/upload-artifact@v4

--- a/e2e/flows/bottom-sheet.yml
+++ b/e2e/flows/bottom-sheet.yml
@@ -1,6 +1,7 @@
 appId: teleport.example
 ---
 - launchApp
+- waitForAnimationToEnd
 - repeat:
     while:
       notVisible:

--- a/e2e/flows/dynamic-children.yml
+++ b/e2e/flows/dynamic-children.yml
@@ -1,6 +1,7 @@
 appId: teleport.example
 ---
 - launchApp
+- waitForAnimationToEnd
 - tapOn:
     id: "dynamic_children"
 - takeScreenshot:

--- a/e2e/flows/instant-root.yml
+++ b/e2e/flows/instant-root.yml
@@ -1,6 +1,7 @@
 appId: teleport.example
 ---
 - launchApp
+- waitForAnimationToEnd
 - tapOn:
     id: "instant_root"
 - tapOn:

--- a/e2e/flows/lifecycle.yml
+++ b/e2e/flows/lifecycle.yml
@@ -1,6 +1,7 @@
 appId: teleport.example
 ---
 - launchApp
+- waitForAnimationToEnd
 - tapOn:
     id: "navigation-lifecycle"
 - takeScreenshot:

--- a/e2e/flows/native-touchable.yml
+++ b/e2e/flows/native-touchable.yml
@@ -1,6 +1,7 @@
 appId: teleport.example
 ---
 - launchApp
+- waitForAnimationToEnd
 - tapOn:
     id: "gesture_handler_touchable"
 - assertVisible:

--- a/e2e/flows/persisted-portal.yml
+++ b/e2e/flows/persisted-portal.yml
@@ -1,6 +1,7 @@
 appId: teleport.example
 ---
 - launchApp
+- waitForAnimationToEnd
 
 # Scroll to the Persisted Portal example (last item in the list)
 - repeat:

--- a/e2e/flows/portal-before-host.yml
+++ b/e2e/flows/portal-before-host.yml
@@ -1,6 +1,7 @@
 appId: teleport.example
 ---
 - launchApp
+- waitForAnimationToEnd
 - tapOn:
     id: "portal_before_host"
 - takeScreenshot:

--- a/e2e/flows/react-native-touchable.yml
+++ b/e2e/flows/react-native-touchable.yml
@@ -1,6 +1,7 @@
 appId: teleport.example
 ---
 - launchApp
+- waitForAnimationToEnd
 - tapOn:
     id: "react_native_touchable"
 - assertVisible:

--- a/e2e/flows/recycling.yml
+++ b/e2e/flows/recycling.yml
@@ -1,6 +1,7 @@
 appId: teleport.example
 ---
 - launchApp
+- waitForAnimationToEnd
 
 # Scroll to the Recycling example (last item in the list)
 - repeat:

--- a/e2e/flows/teleportation-order.yml
+++ b/e2e/flows/teleportation-order.yml
@@ -1,6 +1,7 @@
 appId: teleport.example
 ---
 - launchApp
+- waitForAnimationToEnd
 - tapOn:
     id: "teleportation_order"
 - assertVisible:

--- a/e2e/flows/teleporting.yml
+++ b/e2e/flows/teleporting.yml
@@ -1,6 +1,7 @@
 appId: teleport.example
 ---
 - launchApp
+- waitForAnimationToEnd
 - tapOn:
     id: "gesture_handler_touchable"
 - takeScreenshot:


### PR DESCRIPTION
## 📜 Description

Fixed iOS test flakiness.

## 💡 Motivation and Context

The problem is that simulator after app launch is unbelievably slow and maestro treats it as a unresponsive app. To fix that I:
- boot simulator as soon as possible;
- added timeout for test before launching;

It looks like it fixed a problem 🤞 

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- boot simulator in advance;

### E2E

- use 15s timeout after app launch;

## 🤔 How Has This Been Tested?

Tested manually via this PR.

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<img width="349" height="65" alt="image" src="https://github.com/user-attachments/assets/6c9dc483-21b2-4018-94ce-97a92172c758" />|<img width="256" height="40" alt="image" src="https://github.com/user-attachments/assets/cb1e9d99-2d81-4c38-9c93-939548560390" />|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
