### PR TITLE
fix: publishing to npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,13 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      # Check out the released tag explicitly. On `release` events, older
+      # actions/checkout left HEAD detached at the bare commit, dropping the
+      # tag ref and producing a provenance cert with no SourceRepositoryRef,
+      # which npm rejects (npm/cli#8699).
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## 📜 Description

Fixed a problem with publishing latest release.

## 💡 Motivation and Context

It happens because of checkout action. Sometime it may read a detached commit, which is obviously not verified and because of that package will not be published.

In this PR I'm fixing it.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- bump checkout to v6;
- use  `${{ github.event.release.tag_name }}` as a stable reference;

## 🤔 How Has This Been Tested?

Will test after merge to `main`.

## 📸 Screenshots (if appropriate):

N/A

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
