### PR TITLE
e2e: stable Android tests

### DIFF
--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -124,8 +124,9 @@ jobs:
           profile: pixel_2
           ram-size: "4096M"
           disk-size: "10G"
-          disable-animations: false
+          disable-animations: true
           force-avd-creation: false
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           avd-name: e2e_emulator_${{ matrix.devices.api }}
           arch: x86_64
           script: |

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -121,6 +121,7 @@ jobs:
         with:
           api-level: ${{ matrix.devices.api }}
           target: ${{ matrix.devices.target }}
+          cores: 4
           profile: pixel_2
           ram-size: "4096M"
           disk-size: "10G"


### PR DESCRIPTION
## 📜 Description

Improve Android e2e tests stability.

## 💡 Motivation and Context

Core changes are:
- use 4 cores instead of 2 (as per Maestro CI example);
- disable animations
- use gpu + swiftshader_indirect

All of that should help to boost emulator responsiveness and reduce tests flakiness.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- use 4 cores instead of 2
- disable animations
- use gpu + swiftshader_indirect

## 🤔 How Has This Been Tested?

Tested via this PR.

## 📸 Screenshots (if appropriate):

<img width="296" height="292" alt="image" src="https://github.com/user-attachments/assets/f1f85c50-1c71-4430-aa3c-5642b8a61cab" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
