### PR TITLE
fix: detekt files being published to npm

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -74,7 +74,8 @@
     "portaling",
     "segoe",
     "picsum",
-    "subflows"
+    "subflows",
+    "detekt"
   ],
   "ignorePaths": [
     "node_modules",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "!android/gradlew",
     "!android/gradlew.bat",
     "!android/local.properties",
+    "!android/detekt.yml",
     "!**/__tests__",
     "!**/__fixtures__",
     "!**/__mocks__",


### PR DESCRIPTION
## 📜 Description

Exclude `detekt` files from being published to npm.

## 💡 Motivation and Context

This is dev-only file, it's not used in consumer apps/projects.

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- exclude `detekt` file from being published to npm;

## 🤔 How Has This Been Tested?

Tested via this PR.

## 📸 Screenshots (if appropriate):

<img width="342" height="123" alt="image" src="https://github.com/user-attachments/assets/68b58eaa-eac4-493f-94cd-ee0152f4bb0a" />

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
