### PR TITLE
feat: add tvOS support

### DIFF
--- a/Teleport.podspec
+++ b/Teleport.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => min_ios_version_supported }
+  s.platforms    = { :ios => min_ios_version_supported, :tvos => min_ios_version_supported }
   s.source       = { :git => "https://github.com/kirillzyusko/react-native-teleport.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,cpp}"

--- a/cspell.json
+++ b/cspell.json
@@ -7,6 +7,7 @@
     "Kiryl",
     "Ziusko",
     "podspec",
+    "tvos",
     "gradlew",
     "makeappicon",
     "jsbundle",


### PR DESCRIPTION
## 📜 Description

Adds tvOS to the `Teleport.podspec` platforms so the pod is autolinked and compiled for Apple TV targets.

## 💡 Motivation and Context

On a `react-native-tvos` (New Architecture / Fabric) app, the whole app aborts at launch with:

```
*** Terminating app due to uncaught exception 'NSInvalidArgumentException'
+[NSDictionary dictionaryWithObjects:forKeys:count:]
__61+[RCTThirdPartyComponentsProvider thirdPartyFabricComponents]_block_invoke  (RCTThirdPartyComponentsProvider.mm)
```

React Native's codegen registers `PortalView` / `PortalHostView` in `RCTThirdPartyComponentsProvider` for **every** autolinked component library, resolving each via `NSClassFromString(...)`. Because `Teleport.podspec` declares `:ios` only, the pod is never compiled into the tvOS slice, so those two `NSClassFromString` calls return `nil`, and inserting `nil` into the generated `NSDictionary` literal throws → the app crashes on the first Fabric render.

The native implementation is already platform-agnostic — `PortalView`, `PortalHostView`, `PortalRegistry` and the shared C++ use only cross-platform UIKit (`UIView`, `layoutSubviews`, `hitTest:`, `UIScreen.coordinateSpace`, `RCTSurfaceTouchHandler`). No iOS-only APIs (status bar, scenes, `UIApplication.windows`, etc.). So declaring `:tvos` is sufficient to make portals work on tvOS; no source changes are required. This mirrors how React Native core declares its own pods (`{ :ios => min_ios_version_supported, :tvos => min_ios_version_supported }`).

## 📢 Changelog

### iOS

- Declare `:tvos` in `Teleport.podspec` platforms so the pod is autolinked/compiled for tvOS.

## 🤔 How Has This Been Tested?

Built and ran in a real `react-native-tvos@0.85` New Architecture app on the **tvOS 26.5 simulator (Apple TV)**:

- `pod install` autolinks Teleport and reports: `Supported Apple platforms: ios, tvos for TeleportViewSpec`
- `PortalView` / `PortalHostView` compile for `appletvsimulator` and register in `RCTThirdPartyComponentsProvider`
- App launches without the `NSInvalidArgumentException` crash and portals render on tvOS

## 📝 Checklist

- [ ] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed (n/a — build-config only, no API change)
