### PR TITLE
fix(ios): use host layout bounds for teleported size instead of transform inclusive convertRect

### DIFF
--- a/example/src/constants/screenNames.ts
+++ b/example/src/constants/screenNames.ts
@@ -21,6 +21,7 @@ export enum ScreenNames {
   PHOTO_GALLERY = "PHOTO_GALLERY",
   PHOTO_DETAIL = "PHOTO_DETAIL",
   ORIENTATION = "ORIENTATION",
+  SCALED_HOST = "SCALED_HOST",
 }
 
 export enum StackNames {

--- a/example/src/navigation/ExamplesStack/index.tsx
+++ b/example/src/navigation/ExamplesStack/index.tsx
@@ -30,6 +30,7 @@ import PhotoGallery from "../../screens/PhotoGallery/PhotoGallery";
 import PhotoDetail from "../../screens/PhotoGallery/PhotoDetail";
 import type { Photo } from "../../screens/PhotoGallery/photos";
 import Orientation from "../../screens/Orientation";
+import ScaledHost from "../../screens/ScaledHost";
 
 export type ExamplesStackParamList = {
   [ScreenNames.GESTURE_HANDLER_TOUCHABLE]: undefined;
@@ -62,6 +63,7 @@ export type ExamplesStackParamList = {
   [ScreenNames.PHOTO_GALLERY]: undefined;
   [ScreenNames.PHOTO_DETAIL]: { photo: Photo };
   [ScreenNames.ORIENTATION]: undefined;
+  [ScreenNames.SCALED_HOST]: undefined;
 };
 
 const Stack = createNativeStackNavigator<ExamplesStackParamList>();
@@ -135,6 +137,7 @@ const options = {
     presentation: "containedTransparentModal" as const,
   },
   [ScreenNames.ORIENTATION]: { title: "Orientation" },
+  [ScreenNames.SCALED_HOST]: { title: "Context menu (scaled host)" },
 };
 
 const ExamplesStack = () => (
@@ -258,6 +261,11 @@ const ExamplesStack = () => (
       component={Orientation}
       name={ScreenNames.ORIENTATION}
       options={options[ScreenNames.ORIENTATION]}
+    />
+    <Stack.Screen
+      component={ScaledHost}
+      name={ScreenNames.SCALED_HOST}
+      options={options[ScreenNames.SCALED_HOST]}
     />
   </Stack.Navigator>
 );

--- a/example/src/screens/Main/constants.ts
+++ b/example/src/screens/Main/constants.ts
@@ -111,4 +111,10 @@ export const examples: Example[] = [
     info: ScreenNames.ORIENTATION,
     icons: "🧭",
   },
+  {
+    title: "Context menu (scaled host)",
+    testID: "scaled_host",
+    info: ScreenNames.SCALED_HOST,
+    icons: "📐",
+  },
 ];

--- a/example/src/screens/Main/types.ts
+++ b/example/src/screens/Main/types.ts
@@ -18,7 +18,8 @@ export type ExampleScreen =
   | ScreenNames.RICH_TEXT_EDITOR
   | ScreenNames.PERSISTED_PORTAL
   | ScreenNames.PHOTO_GALLERY
-  | ScreenNames.ORIENTATION;
+  | ScreenNames.ORIENTATION
+  | ScreenNames.SCALED_HOST;
 
 export type Example = {
   testID: string;

--- a/example/src/screens/ScaledHost/index.tsx
+++ b/example/src/screens/ScaledHost/index.tsx
@@ -230,7 +230,6 @@ const styles = StyleSheet.create({
   },
   readout: {
     color: "#0f172a",
-    fontVariant: ["tabular-nums"],
   },
   screen: {
     flex: 1,

--- a/example/src/screens/ScaledHost/index.tsx
+++ b/example/src/screens/ScaledHost/index.tsx
@@ -1,0 +1,243 @@
+import { useState } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+} from "react-native-reanimated";
+import { Portal, PortalHost } from "react-native-teleport";
+
+type Size = { w: number; h: number };
+
+// A message bubble to anchor the menu around, mimicking a long pressed message.
+const MESSAGE = { h: 96, w: 300, x: 40, y: 340 };
+// Fixed host sizes used by scale only mode (roughly the natural content sizes).
+const TOP_FIXED: Size = { h: 52, w: 220 };
+const BOTTOM_FIXED: Size = { h: 176, w: 220 };
+// Below this width the teleported top item has clearly collapsed. Used only for
+// the on screen OK/COLLAPSED status.
+const TOP_OK_MIN_WIDTH = 160;
+
+const REACTIONS = ["👍", "❤️", "😂", "😮", "😢"];
+const ACTIONS = ["Reply", "Copy", "Edit", "Delete"];
+
+const format = (r: Size | null) =>
+  r ? `${Math.round(r.w)} x ${Math.round(r.h)}` : "-";
+
+export default function ScaledHost() {
+  const [active, setActive] = useState(false);
+  const [feedback, setFeedback] = useState(true);
+  // Kept in React state only for the on screen readout of the bug, not really needed
+  // otherwise.
+  const [topSize, setTopSize] = useState<Size | null>(null);
+  const [bottomSize, setBottomSize] = useState<Size | null>(null);
+
+  const topWH = useSharedValue<Size>(TOP_FIXED);
+  const bottomWH = useSharedValue<Size>(BOTTOM_FIXED);
+  const backdrop = useSharedValue(0);
+
+  const open = () => {
+    setActive(true);
+    backdrop.value = withSpring(1, { duration: 400 });
+  };
+
+  const close = () => {
+    setActive(false);
+    backdrop.value = withSpring(0, { duration: 300 });
+    topWH.value = TOP_FIXED;
+    bottomWH.value = BOTTOM_FIXED;
+    setTopSize(null);
+    setBottomSize(null);
+  };
+
+  const topItemStyle = useAnimatedStyle(() => {
+    const size = feedback ? topWH.value : TOP_FIXED;
+    return {
+      height: size.h,
+      left: MESSAGE.x,
+      position: "absolute",
+      top: MESSAGE.y - size.h,
+      transform: [{ scale: backdrop.value }],
+      width: size.w,
+    };
+  });
+
+  const bottomItemStyle = useAnimatedStyle(() => {
+    const size = feedback ? bottomWH.value : BOTTOM_FIXED;
+    return {
+      height: size.h,
+      left: MESSAGE.x,
+      position: "absolute",
+      top: MESSAGE.y + MESSAGE.h,
+      transform: [{ scale: backdrop.value }],
+      width: size.w,
+    };
+  });
+
+  const topOk = topSize ? topSize.w >= TOP_OK_MIN_WIDTH : null;
+
+  return (
+    <View style={styles.screen}>
+      <Pressable
+        disabled={active}
+        onPress={() => setFeedback((f) => !f)}
+        style={[styles.mode, active && styles.modeDisabled]}
+        testID="sizing_mode"
+      >
+        <Text style={styles.modeText}>
+          sizing: {feedback ? "feedback" : "scale-only"}
+          {active ? "" : " (tap to switch)"}
+        </Text>
+      </Pressable>
+
+      <Text style={styles.readout} testID="top_measured">
+        top: {format(topSize)}
+      </Text>
+      <Text style={styles.readout} testID="bottom_measured">
+        bottom: {format(bottomSize)}
+      </Text>
+      <Text style={styles.status} testID="top_status">
+        status:{" "}
+        {active ? (topOk === null ? "…" : topOk ? "OK" : "COLLAPSED") : "idle"}
+      </Text>
+      <Pressable
+        onPress={active ? close : open}
+        style={styles.button}
+        testID="context_menu_toggle"
+      >
+        <Text style={styles.buttonText}>
+          {active ? "Close" : "Open context menu"}
+        </Text>
+      </Pressable>
+
+      <Portal hostName={active ? "top-item" : undefined}>
+        {active ? (
+          <View
+            onLayout={(e) => {
+              const { width: w, height: h } = e.nativeEvent.layout;
+              topWH.value = { h, w };
+              setTopSize({ h, w });
+            }}
+            style={styles.reactionBar}
+          >
+            {REACTIONS.map((r) => (
+              <Text key={r} style={styles.reaction}>
+                {r}
+              </Text>
+            ))}
+          </View>
+        ) : null}
+      </Portal>
+
+      <Portal hostName={active ? "bottom-item" : undefined}>
+        {active ? (
+          <View
+            onLayout={(e) => {
+              const { width: w, height: h } = e.nativeEvent.layout;
+              bottomWH.value = { h, w };
+              setBottomSize({ h, w });
+            }}
+            style={styles.actionList}
+          >
+            {ACTIONS.map((a) => (
+              <Text key={a} style={styles.action}>
+                {a}
+              </Text>
+            ))}
+          </View>
+        ) : null}
+      </Portal>
+
+      <View style={styles.message}>
+        <Text style={styles.messageText}>Long-pressed message</Text>
+      </View>
+
+      <Animated.View pointerEvents="box-none" style={topItemStyle}>
+        <PortalHost name="top-item" style={StyleSheet.absoluteFill} />
+      </Animated.View>
+      <Animated.View pointerEvents="box-none" style={bottomItemStyle}>
+        <PortalHost name="bottom-item" style={StyleSheet.absoluteFill} />
+      </Animated.View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  action: {
+    color: "#0f172a",
+    fontSize: 16,
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+  },
+  actionList: {
+    backgroundColor: "#fff",
+    borderColor: "#e2e8f0",
+    borderRadius: 12,
+    borderWidth: StyleSheet.hairlineWidth,
+  },
+  button: {
+    alignSelf: "flex-start",
+    backgroundColor: "#2563eb",
+    borderRadius: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+  },
+  buttonText: {
+    color: "#fff",
+    fontWeight: "600",
+  },
+  message: {
+    backgroundColor: "#4f83ff",
+    borderRadius: 16,
+    height: MESSAGE.h,
+    justifyContent: "center",
+    left: MESSAGE.x,
+    paddingHorizontal: 16,
+    position: "absolute",
+    top: MESSAGE.y,
+    width: MESSAGE.w,
+  },
+  messageText: {
+    color: "#fff",
+    fontWeight: "600",
+  },
+  mode: {
+    alignSelf: "flex-start",
+    backgroundColor: "#e2e8f0",
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  modeDisabled: {
+    opacity: 0.5,
+  },
+  modeText: {
+    color: "#0f172a",
+    fontWeight: "600",
+  },
+  reaction: {
+    fontSize: 26,
+  },
+  reactionBar: {
+    backgroundColor: "#fff",
+    borderColor: "#e2e8f0",
+    borderRadius: 24,
+    borderWidth: StyleSheet.hairlineWidth,
+    flexDirection: "row",
+    gap: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+  },
+  readout: {
+    color: "#0f172a",
+    fontVariant: ["tabular-nums"],
+  },
+  screen: {
+    flex: 1,
+    gap: 6,
+    padding: 16,
+  },
+  status: {
+    fontWeight: "700",
+  },
+});

--- a/ios/PortalView.mm
+++ b/ios/PortalView.mm
@@ -102,9 +102,11 @@ using namespace facebook::react;
   // Children are physically mounted under the host, but measured through this
   // PortalView shadow node. Store the host's native layout so Fabric
   // measurement follows the destination after it re-layouts.
+  CGSize hostSize = self.targetView.bounds.size;
+
   PortalViewState newData = {
-      static_cast<Float>(hostRect.size.width),
-      static_cast<Float>(hostRect.size.height),
+      static_cast<Float>(hostSize.width),
+      static_cast<Float>(hostSize.height),
       static_cast<Float>(hostRect.origin.x - sourceRect.origin.x),
       static_cast<Float>(hostRect.origin.y - sourceRect.origin.y)};
 


### PR DESCRIPTION
## 📜 Description

On `iOS`, teleported children collapse to roughly `1×1` (or some similar intermediary dimension like this) when any ancestor of the `PortalHost` has a `scale` transform (typical for a context-menu/popover open animation).

My proposed fix is one line of behaviour in `ios/PortalView.mm` publish the host's untransformed layout size (`self.targetView.bounds.size`) as the `Yoga` size constraint, instead of the transform inclusive size returned by `convertRect:toCoordinateSpace:`. The offset is left alone as it still needs the on screen delta.

Also adds an example screen that reproduces the regression, since the existing tests didn't cover this path specifically.

## 💡 Motivation and Context

The issue was introduced `1.1.11`, [this PR](https://github.com/kirillzyusko/react-native-teleport/commits/main/). While the change is correct and good, the change started pinning a teleported `PortalView` to its host's size as a `Yoga` constraint, so children relayout when the host resizes (e.g. rotation). The idea is right but the problem I believe is only how iOS reads "the host's size".

iOS measures it with `-[UIView convertRect:toCoordinateSpace:]`:

```objc
CGRect hostRect = [self screenRectForView:self.targetView];
// ...
static_cast<Float>(hostRect.size.width)   // fed straight into the Yoga width/height pin
```

`convertRect:` walks up the view hierarchy and applies every ancestor `CGAffineTransform`, so it returns the on screen size, not the layout size. When something above the host carries `scale(s)`, the reported size is `(w x s) × (h x s)` and the teleported subtree gets pinned to that. A transform is not a layout change, so nothing ever fires `updatePortalLayoutStateIfNeeded` again to correct it once the animation settles and so the content stays collapsed (to whatever stale size it received in the very first update). This makes it totally arbitrary as to how it reproduces in general.

With no transform in the chain the two are equal, which is why it went unnoticed until an animated `scale` sat above a host. Pinning `width` and `height` of the view helps to reproduce this way more easily, since these trigger an intermediate layout pass, which, if it happens during the transform will produce a stale layout until something changes (either a forced render that is going to update the underlying `ShadowNode` and the component conversely or something similar that is going to force a generic layout commit). For example, I also noticed that enabling `FORCE_REACT_RENDER_FOR_SETTLED_ANIMATIONS` on `react-native-reanimated` sometimes fixes the issue organically (because it will force a layout pass just as the animation finishes). This however depends on whether we're lucky to have the animation happen outside of the `500ms` GC pass that the feature flag relies on, but it still confirms the theory a bit better !

Android was never affected, as `PortalLayoutStateController` publishes `host.width/height`, which is layout size and transform independent. This change makes iOS do the same thing.

## 📢 Changelog

### iOS

- Use the host's untransformed `bounds.size` for the teleported view's pinned `Yoga` size instead of the transform inclusive `convertRect:` size. Teleported content no longer collapses when an ancestor of the host has a `scale` transform. Offset handling is unchanged.

## 🤔 How Has This Been Tested?

- **New example screen** (`Context menu (scaled host)`) reproduces a sample overlay mechanism, auto sized content is teleported into a host whose animated wrapper takes its size from the measured content and scales in on open. Before the fix it collapses to a few `px` on open while after it settles at the content's natural size and scales in cleanly. The screen has a `feedback` / `scale-only` toggle showing that the size against scale feedback loop makes the collapse deterministic, while a fixed size host only trips it intermittently (it is still totally reproducible with `scale` only as well, just doesn't happen as often)
- **Rotation (the #157 case) still works** rotating changes the host's *layout*, which refires `-layoutSubviews`, so the pin readopts the new host size. The fix only stops *transforms* from feeding the size, so actual layout changes should still propagate

I also created my attempt at updating the E2E tests, but have not committed that yet - if we're good with the change and you'd like me to I'd also be happy to update the E2E suite !

## 📸 Screenshots (if appropriate):

<table>                                                                                                                                                                                                        
    <tr>                                                                                                                                                                                                         
      <th>Before (1.1.11)</th>                                                                                                                                                                                   
      <th>After (fix)</th>                                                                                                                                                                                       
    </tr>                                                                                                                                                                                                        
    <tr>                                                                                                                                                                                                         
      <td>                                                                                                                                                                                                       
        <video src="https://github.com/user-attachments/assets/4463ee52-0f64-4de8-a5f3-0a20a36a8404" controls></video>                                                                                           
      </td>                                                                                                                                                                                                      
      <td>                                                                                                                                                                                                       
        <video src="https://github.com/user-attachments/assets/7af5c0d6-83b8-45de-aeb2-24138773731f" controls></video>                                                                                           
      </td>                                                                                                                                                                                                      
    </tr>                                                                                                                                                                                                        
  </table>     

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed <!-- no library API change; covered by the example screen + e2e flow -->
