### PR TITLE
e2e: assure we use correct host layout

### DIFF
--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -92,8 +92,10 @@ jobs:
           path: example/android/app/build/outputs/apk/
       - name: Install Maestro
         run: |
+          export MAESTRO_VERSION=2.6.1
           curl -fsSL "https://get.maestro.mobile.dev" | bash
           echo "$HOME/.maestro/bin" >> $GITHUB_PATH
+          maestro --version
           export MAESTRO_DRIVER_STARTUP_TIMEOUT=600000
       - name: Enable KVM group perms
         run: |

--- a/.github/workflows/android-e2e-test.yml
+++ b/.github/workflows/android-e2e-test.yml
@@ -95,8 +95,9 @@ jobs:
           export MAESTRO_VERSION=2.6.1
           curl -fsSL "https://get.maestro.mobile.dev" | bash
           echo "$HOME/.maestro/bin" >> $GITHUB_PATH
-          maestro --version
           export MAESTRO_DRIVER_STARTUP_TIMEOUT=600000
+      - name: Log Maestro version
+        run: maestro --version
       - name: Enable KVM group perms
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -138,7 +138,8 @@ jobs:
           export MAESTRO_VERSION=2.6.1
           curl -fsSL "https://get.maestro.mobile.dev" | bash
           echo "$HOME/.maestro/bin" >> $GITHUB_PATH
-          maestro --version
+      - name: Log Maestro version
+        run: maestro --version
       - name: Prepare snapshot engine
         run: cd e2e && npm install
       - name: Run E2E tests

--- a/.github/workflows/ios-e2e-test.yml
+++ b/.github/workflows/ios-e2e-test.yml
@@ -135,8 +135,10 @@ jobs:
           xcrun simctl install "$UDID" example/ios/build/Build/Products/Release-iphonesimulator/TeleportExample.app
       - name: Install Maestro CLI
         run: |
-          brew tap mobile-dev-inc/tap
-          brew install mobile-dev-inc/tap/maestro
+          export MAESTRO_VERSION=2.6.1
+          curl -fsSL "https://get.maestro.mobile.dev" | bash
+          echo "$HOME/.maestro/bin" >> $GITHUB_PATH
+          maestro --version
       - name: Prepare snapshot engine
         run: cd e2e && npm install
       - name: Run E2E tests

--- a/.github/workflows/web-e2e-test.yml
+++ b/.github/workflows/web-e2e-test.yml
@@ -64,8 +64,9 @@ jobs:
           export MAESTRO_VERSION=2.6.1
           curl -fsSL "https://get.maestro.mobile.dev" | bash
           echo "$HOME/.maestro/bin" >> $GITHUB_PATH
-          maestro --version
           export MAESTRO_DRIVER_STARTUP_TIMEOUT=600000
+      - name: Log Maestro version
+        run: maestro --version
       - name: Specify web env
         run: |
           find e2e/flows -name "*.yml" -exec sh -c '

--- a/.github/workflows/web-e2e-test.yml
+++ b/.github/workflows/web-e2e-test.yml
@@ -61,8 +61,10 @@ jobs:
           echo $! > .server-pid
       - name: Install Maestro
         run: |
+          export MAESTRO_VERSION=2.6.1
           curl -fsSL "https://get.maestro.mobile.dev" | bash
           echo "$HOME/.maestro/bin" >> $GITHUB_PATH
+          maestro --version
           export MAESTRO_DRIVER_STARTUP_TIMEOUT=600000
       - name: Specify web env
         run: |

--- a/e2e/flows/bottom-sheet.yml
+++ b/e2e/flows/bottom-sheet.yml
@@ -2,16 +2,10 @@ appId: teleport.example
 ---
 - launchApp
 - waitForAnimationToEnd
-- repeat:
-    while:
-      notVisible:
-        id: "bottom_sheet"
-    commands:
-      - swipe:
-          start: 50%, 80%
-          end: 50%, 20%
-- tapOn:
-    id: "bottom_sheet"
+- runFlow:
+    file: ../subflows/open-example.yml
+    env:
+      EXAMPLE_ID: "bottom_sheet"
 - assertNotVisible:
     text: "Sheet"
 - assertNotVisible:

--- a/e2e/flows/navigation-view-ownership.yml
+++ b/e2e/flows/navigation-view-ownership.yml
@@ -2,21 +2,11 @@ appId: teleport.example
 ---
 - launchApp
 
-# Scroll to the Rich Text Editor example.
-- repeat:
-    while:
-      notVisible:
-        id: "rich_text_editor"
-    commands:
-      - swipe:
-          start: 50%, 80%
-          end: 50%, 20%
-# do additional swipe for headless web, this is Maestro bug
-- swipe:
-    start: 50%, 75%
-    end: 50%, 55%
-- tapOn:
-    id: "rich_text_editor"
+# Open the Rich Text Editor example.
+- runFlow:
+    file: ../subflows/open-example.yml
+    env:
+      EXAMPLE_ID: "rich_text_editor"
 
 # Teleport the preloaded editor into the screen-local host.
 - tapOn:

--- a/e2e/flows/orientation.yml
+++ b/e2e/flows/orientation.yml
@@ -8,12 +8,10 @@ appId: teleport.example
       - launchApp
       - setOrientation: PORTRAIT
       - waitForAnimationToEnd
-      - scrollUntilVisible:
-          element:
-            id: "orientation"
-          direction: DOWN
-      - tapOn:
-          id: "orientation"
+      - runFlow:
+          file: ../subflows/open-example.yml
+          env:
+            EXAMPLE_ID: "orientation"
       - assertVisible:
           id: "orientation_toggle"
       - assertVisible:

--- a/e2e/flows/persisted-portal.yml
+++ b/e2e/flows/persisted-portal.yml
@@ -3,17 +3,11 @@ appId: teleport.example
 - launchApp
 - waitForAnimationToEnd
 
-# Scroll to the Persisted Portal example (last item in the list)
-- repeat:
-    while:
-      notVisible:
-        id: "persisted_portal"
-    commands:
-      - swipe:
-          start: 50%, 80%
-          end: 50%, 20%
-- tapOn:
-    id: "persisted_portal"
+# Open the Persisted Portal example.
+- runFlow:
+    file: ../subflows/open-example.yml
+    env:
+      EXAMPLE_ID: "persisted_portal"
 
 - takeScreenshot:
     path: e2e/PersistedPortalWithoutHost

--- a/e2e/flows/recycling.yml
+++ b/e2e/flows/recycling.yml
@@ -3,17 +3,11 @@ appId: teleport.example
 - launchApp
 - waitForAnimationToEnd
 
-# Scroll to the Recycling example (last item in the list)
-- repeat:
-    while:
-      notVisible:
-        id: "recycling"
-    commands:
-      - swipe:
-          start: 50%, 80%
-          end: 50%, 20%
-- tapOn:
-    id: "recycling"
+# Open the Recycling example.
+- runFlow:
+    file: ../subflows/open-example.yml
+    env:
+      EXAMPLE_ID: "recycling"
 
 # Step 1: Teleport into the host for the first time
 - tapOn:

--- a/e2e/flows/scaled-host.yml
+++ b/e2e/flows/scaled-host.yml
@@ -2,12 +2,10 @@ appId: teleport.example
 ---
 - launchApp
 - waitForAnimationToEnd
-- scrollUntilVisible:
-    element:
-      id: "scaled_host"
-    direction: DOWN
-- tapOn:
-    id: "scaled_host"
+- runFlow:
+    file: ../subflows/open-example.yml
+    env:
+      EXAMPLE_ID: "scaled_host"
 - assertVisible:
     id: "context_menu_toggle"
 - tapOn:

--- a/e2e/flows/scaled-host.yml
+++ b/e2e/flows/scaled-host.yml
@@ -1,0 +1,16 @@
+appId: teleport.example
+---
+- launchApp
+- waitForAnimationToEnd
+- scrollUntilVisible:
+    element:
+      id: "scaled_host"
+    direction: DOWN
+- tapOn:
+    id: "scaled_host"
+- assertVisible:
+    id: "context_menu_toggle"
+- tapOn:
+    id: "context_menu_toggle"
+- waitForAnimationToEnd
+- assertVisible: "status: OK"

--- a/e2e/subflows/open-example.yml
+++ b/e2e/subflows/open-example.yml
@@ -1,0 +1,33 @@
+appId: teleport.example
+---
+# Required env: EXAMPLE_ID — testID of an example on the home screen.
+#
+# Web's scrollUntilVisible does not reliably drive React Native Web's list, so
+# find the item with explicit swipes there. Native platforms use Maestro's
+# normal scrolling command.
+- runFlow:
+    when:
+      platform: Web
+    commands:
+      - repeat:
+          while:
+            notVisible:
+              id: ${EXAMPLE_ID}
+          commands:
+            - swipe:
+                start: 50%, 80%
+                end: 50%, 20%
+      # Maestro Web needs one final gesture before a just-found item is pressable.
+      - swipe:
+          start: 50%, 75%
+          end: 50%, 55%
+- runFlow:
+    when:
+      true: ${maestro.platform == 'ios' || maestro.platform == 'android'}
+    commands:
+      - scrollUntilVisible:
+          element:
+            id: ${EXAMPLE_ID}
+          direction: DOWN
+- tapOn:
+    id: ${EXAMPLE_ID}


### PR DESCRIPTION
## 📜 Description

Cover regressions that fixed in https://github.com/kirillzyusko/react-native-teleport/pull/161 by e2e test. Lock maestro version to avoid false-green reports.

## 💡 Motivation and Context

We need to cover new code with e2e tests because this is the only one way to make the library stable. Such edge cases that we discovered we would never be able to catch manually. So more examples + more e2e tests will make the lib really stable 🤞 

I also realized that our CI was unstable, because it used different maestro version (comparing to what I have installed locally). So in this PR I locked maestro version to `2.6.1` (it should tests really work and really compare screenshots).

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### CI

- lock maestro version to `2.6.1` (`2.7.0` can not take screenshots);

### E2E

- added `open-example` subflow;
- added `scaled-host` test;

## 🤔 How Has This Been Tested?

Tested via this PR.

## 📸 Screenshots (if appropriate):

<!-- Add screenshots/video if needed -->
<!-- That would be highly appreciated if you can add how it looked before and after your changes -->

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
