### PR TITLE
fix: a11y crash when view is teleported

### DIFF
--- a/android/src/main/java/com/teleport/portal/PortalView.kt
+++ b/android/src/main/java/com/teleport/portal/PortalView.kt
@@ -3,6 +3,7 @@ package com.teleport.portal
 import android.content.Context
 import android.view.View
 import android.view.ViewGroup
+import android.view.accessibility.AccessibilityEvent
 import com.facebook.react.uimanager.StateWrapper
 import com.facebook.react.views.view.ReactViewGroup
 import com.teleport.global.PortalRegistry
@@ -274,5 +275,10 @@ class PortalView(
     }
     // When teleported, do nothing—children are handled by the host's accessibility tree
   }
+
+  // A teleported child is no longer a physical descendant of this view.
+  // The host traverses it at its actual location instead.
+  override fun dispatchPopulateAccessibilityEvent(event: AccessibilityEvent): Boolean =
+    if (isTeleported) false else super.dispatchPopulateAccessibilityEvent(event)
   // endregion
 }


### PR DESCRIPTION
## 📜 Description

Fixed a crash that occurred when pressing an RNGH `Pressable` while one of its children was teleported.

## 💡 Context and Motivation

`PortalView` keeps its children logically attached so React Native can continue to manage them, but once a matching host exists those children are physically reparented into `PortalHostView`. This means a teleported child can be returned by `PortalView.getChildAt()` even though it is no longer a descendant in Android's native view hierarchy.

When an RNGH `Pressable` performs a click, Android emits an accessibility event. `ViewGroup.dispatchPopulateAccessibilityEvent()` then traverses the logical children and tries to translate their bounds with `offsetDescendantRectToMyCoords()`. That API requires a physical descendant, so the teleported child causes:

```text
java.lang.IllegalArgumentException: parameter must be a descendant of this view
at ViewGroup.offsetDescendantRectToMyCoords
at ViewGroup.dispatchPopulateAccessibilityEventInternal
at RNGestureHandlerButtonViewManager$ButtonViewGroup.performClick
```

The fix stops accessibility-event population at `PortalView` only while its children are teleported. The children are not removed from the accessibility tree: `PortalHostView`, where they physically live, still exposes and traverses them at the correct screen location. When no host exists and the children remain physically attached to `PortalView`, the implementation delegates to `super` and preserves normal Android accessibility behavior.

This follows the same pattern used by React Native's Android [`ReactModalHostView`](https://github.com/facebook/react-native/blob/v0.81.0/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt#L186-L193). A modal keeps a logical placeholder in the normal React hierarchy while rendering its children inside a separate `DialogRootViewGroup`; React Native therefore overrides both `addChildrenForAccessibility()` and `dispatchPopulateAccessibilityEvent()`, returning `false` from the latter because the dialog host owns accessibility traversal. Teleport uses the conditional version because, unlike a mounted modal, a portal can temporarily own its children physically before a matching host is available.

### Why this approach

- The existing `addChildrenForAccessibility()` override is not sufficient for this event path: Android's internal population traversal still reaches the logical children through the `ViewGroup` child APIs.
- Returning physical children from `getChildCount()` / `getChildAt()` would break the logical child model used for React Native mutations, ordering, and host lifecycle changes.
- Catching `IllegalArgumentException` would hide an invalid traversal after it has started and could mask unrelated framework errors.
- Re-emitting or proxying accessibility events manually would duplicate behavior already provided by the physical host and risks incorrect bounds or duplicate announcements.
- Returning `false` unconditionally would suppress valid accessibility population while the portal's children are still physically attached. The `isTeleported` guard limits the behavior change to the invalid-tree state that causes the crash.

Reproduction:

```tsx
import { useState } from "react";
import { StyleSheet, Text, View } from "react-native";
import { Pressable } from "react-native-gesture-handler";
import { Portal, PortalHost } from "react-native-teleport";

const HOST_NAME = "accessibility-traversal-repro";

export default function AccessibilityTraversal() {
  const [pressCount, setPressCount] = useState(0);

  return (
    <View style={styles.container}>
      <Text style={styles.instructions}>
        With an Android screen reader enabled, press the source button while its
        child is teleported to the destination host.
      </Text>

      <Pressable
        accessibilityRole="button"
        onPress={() => setPressCount((count) => count + 1)}
        style={({ pressed }) => [
          styles.sourcePressable,
          pressed && styles.sourcePressablePressed,
        ]}
        testID="accessibility-source-pressable"
      >
        <Text style={styles.sourceLabel}>Trigger source pressable</Text>
        <Portal hostName={HOST_NAME}>
          <View
            accessible
            accessibilityLabel="Teleported child"
            style={styles.teleportedChild}
            testID="accessibility-teleported-child"
          >
            <Text style={styles.teleportedChildText}>Teleported child</Text>
          </View>
        </Portal>
      </Pressable>

      <Text testID="accessibility-press-count">Press count: {pressCount}</Text>

      <View style={styles.destination}>
        <Text style={styles.destinationLabel}>Destination host</Text>
        <PortalHost name={HOST_NAME} style={styles.host} />
      </View>
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    gap: 24,
    padding: 24,
  },
  instructions: {
    color: "#333333",
    fontSize: 16,
    lineHeight: 22,
  },
  sourcePressable: {
    alignItems: "center",
    alignSelf: "stretch",
    backgroundColor: "#275dad",
    borderRadius: 8,
    minHeight: 56,
    justifyContent: "center",
    paddingHorizontal: 16,
  },
  sourcePressablePressed: {
    opacity: 0.7,
  },
  sourceLabel: {
    color: "white",
    fontSize: 16,
    fontWeight: "600",
  },
  destination: {
    borderColor: "#777777",
    borderRadius: 8,
    borderStyle: "dashed",
    borderWidth: 2,
    flex: 1,
    minHeight: 180,
    overflow: "hidden",
  },
  destinationLabel: {
    color: "#555555",
    fontSize: 14,
    padding: 12,
  },
  host: {
    flex: 1,
    padding: 16,
  },
  teleportedChild: {
    alignItems: "center",
    backgroundColor: "#f7c548",
    borderRadius: 8,
    height: 120,
    justifyContent: "center",
  },
  teleportedChildText: {
    color: "#222222",
    fontSize: 18,
    fontWeight: "600",
  },
});
```

This should originally have been handled in https://github.com/kirillzyusko/react-native-teleport/pull/7, but is being fixed now.

Closes https://github.com/kirillzyusko/react-native-teleport/issues/164

## 📢 Changelog

### Android

- Prevent invalid accessibility traversal through teleported children.

## 🤔 How Has This Been Tested?

Tested on an Android 9 emulator with active accessibility traversal.

- Before: pressing the source `Pressable` crashes with `IllegalArgumentException`.
- After: the app remains open, the press handler runs, and no Android runtime crash is logged.

## 📸 Screenshots (if appropriate):

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/4cec116a-e722-4fc5-87c7-1878b24d9ec2"> | <video src="https://github.com/user-attachments/assets/10e92da0-43eb-4d3a-8cfe-ace2dba9d236"> |

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
