### PR TITLE
fix: image flickering once in Photo Gallery example

### DIFF
--- a/example/src/screens/PhotoGallery/PhotoPreview.tsx
+++ b/example/src/screens/PhotoGallery/PhotoPreview.tsx
@@ -102,10 +102,7 @@ function PhotoPreview({ photo, onOpen }: Props) {
             }
           >
             <Animated.Image
-              style={[
-                { width: THUMB_SIZE, opacity: source },
-                isAnimating ? animatedHeight : styles.thumb,
-              ]}
+              style={[{ width: THUMB_SIZE, opacity: source }, animatedHeight]}
               source={{ uri: photo.thumbnail }}
               resizeMode="cover"
             />
@@ -117,9 +114,6 @@ function PhotoPreview({ photo, onOpen }: Props) {
 }
 
 const styles = StyleSheet.create({
-  thumb: {
-    height: THUMB_SIZE,
-  },
   animating: {
     transformOrigin: "0% 0%",
   },


### PR DESCRIPTION
## 📜 Description

Fixed image glitching on Android (in Photo Gallery).

## 💡 Motivation and Context

The Android Photo Gallery example flickered the first time each `Animated.Image` was opened:

- It happened only on the first transition for each image.
- Subsequent transitions were clean.
- It affected React Native `Image`, but not Lottie or video.
- The JS worklet never returned `height: 0`.

The original component conditionally swapped between two different style sources:

```tsx
<Animated.Image
  style={[
    { width: THUMB_SIZE, opacity: source },
    isAnimating ? animatedHeight : styles.thumb,
  ]}
/>
```

Before the animation, the height came from `styles.thumb`. When the animation began:

1. The static height style was removed.
2. `animatedHeight` was attached to the component for the first time.
3. During that first Fabric commit, **Reanimated had not yet supplied the animated style’s native value**.
4. React Native’s Android Image shadow node is a Yoga leaf, so the missing effective height was resolved as `0`.
5. Reanimated supplied the correct height on the next UI update.

Therefore, `360×0` referred to the native computed layout - not a `height: 0` value returned by the worklet.

This was visible specifically with `Image` because its drawable is bounded by the native view dimensions. When the view temporarily becomes zero-height, the drawable disappears.

### 1️⃣ Initial Teleport-level workaround

The first proposed solution was to protect React Native Images during an attached reparent. It temporarily rejected a zero-sized layout and kept the previous non-zero bounds until a valid Reanimated layout arrived.

This extension was added to `View.kt`:

```kotlin
import android.view.View
import android.view.ViewGroup
import com.facebook.react.views.image.ReactImageView

/**
 * Keeps a React Native Image drawable from becoming observable at zero size
 * during an attached reparent.
 *
 * On the first swap from a static layout style to a Reanimated layout style,
 * Fabric can briefly lay out the leaf Image shadow node with a zero dimension
 * before Reanimated supplies its initial native value. Preserve the previous
 * non-zero dimension for that handoff, then release the guard as soon as the
 * valid layout arrives.
 */
internal fun View.preserveReactImageLayoutAcrossReparent() {
  fun preserve(view: View) {
    if (view is ReactImageView && view.width > 0 && view.height > 0) {
      val previousWidth = view.width
      val previousHeight = view.height
      var restoring = false
      var pendingZeroLayout: IntArray? = null
      lateinit var listener: View.OnLayoutChangeListener

      listener =
        View.OnLayoutChangeListener {
            target,
            left,
            top,
            right,
            bottom,
            _,
            _,
            _,
            _,
          ->
          if (restoring) {
            return@OnLayoutChangeListener
          }

          val width = right - left
          val height = bottom - top

          if (width == 0 || height == 0) {
            pendingZeroLayout = intArrayOf(left, top, right, bottom)

            restoring = true
            target.layout(
              left,
              top,
              left + if (width == 0) previousWidth else width,
              top + if (height == 0) previousHeight else height,
            )
            restoring = false
          } else if (pendingZeroLayout != null) {
            pendingZeroLayout = null
            target.removeOnLayoutChangeListener(listener)
          }
        }

      view.addOnLayoutChangeListener(listener)

      view.postOnAnimation {
        view.postOnAnimation {
          view.removeOnLayoutChangeListener(listener)

          // If no valid layout arrived, preserve the original Fabric intent.
          // This matters when zero size was intentional rather than transient.
          pendingZeroLayout?.let { bounds ->
            view.layout(bounds[0], bounds[1], bounds[2], bounds[3])
          }
        }
      }
    }

    if (view is ViewGroup) {
      for (index in 0 until view.childCount) {
        preserve(view.getChildAt(index))
      }
    }
  }

  preserve(this)
}
```

It was called immediately before the attached reparent in `PortalView.kt`:

```kotlin
import com.teleport.extensions.canReparentAttached
import com.teleport.extensions.preserveReactImageLayoutAcrossReparent

// ...

val parent = child.parent as? ViewGroup ?: return
val canReparentAttached =
  target != null && child.canReparentAttached(parent, target)

if (canReparentAttached) {
  child.preserveReactImageLayoutAcrossReparent()

  when (parent) {
    is PortalView -> parent.detachForReparent(child)
    is PortalHostView -> parent.detachForReparent(child)
    else -> parent.removeView(child)
  }

  // Continue attached reparent...
}
```

The two-frame timeout served an important purpose:

- If Reanimated supplied a valid size, the listener was immediately removed.
- If the application really intended to set `height: 0`, that layout was only delayed and then reapplied.

### ❓ Why we didn’t keep this solution

Although the native guard removed the visible flicker, it was treating the symptom at the wrong abstraction level.

The main concerns were:

- Teleport did not create the invalid layout. The gap was caused by conditionally introducing a Reanimated style after the component’s initial render.
- The workaround depended on React Native’s internal `ReactImageView` implementation.
- It made Teleport aware of one particular descendant component type.
- It recursively traversed descendants and installed temporary layout listeners.
- It could delay a legitimate zero-size Image layout by two frames.
- Similar special cases might eventually be required for other React Native components.
- Removing or changing Teleport’s normal layout update did not address the underlying style handoff.

In other words, the workaround made Teleport compensate for a Reanimated/Fabric lifecycle edge case.

### 🎉  Final simpler solution

The animated height already returned a valid baseline when the image was inactive:

```tsx
const animatedHeight = useAnimatedStyle(
  () => ({
    height: isAnimating
      ? interpolate(
          progress.value,
          [0, 1],
          [THUMB_SIZE, THUMB_SIZE + diff],
        )
      : THUMB_SIZE,
  }),
  [isAnimating, diff],
);
```

Therefore, the style did not need to be conditionally attached. The final implementation keeps it attached for the entire component lifetime:

```tsx
<Animated.Image
  style={[
    {
      width: THUMB_SIZE,
      opacity: source,
    },
    animatedHeight,
  ]}
  source={{ uri: photo.thumbnail }}
  resizeMode="cover"
/>
```

The separate static height became unnecessary:

```tsx
const styles = StyleSheet.create({
  animating: {
    transformOrigin: "0% 0%",
  },
});
```

This fixes the lifecycle problem directly:

1. `animatedHeight` is present during the initial render.
2. Reanimated registers and seeds the animated style immediately.
3. The inactive value supplies `height: THUMB_SIZE`.
4. When animation begins, there is no static-to-animated style handoff.
5. Fabric never observes a commit without an effective Image height.

Fixes a note in https://github.com/kirillzyusko/react-native-teleport/pull/98

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### JS

- keep animated style always attached to avoid random `0` height on first animated style attachment;

## 🤔 How Has This Been Tested?

Tested on Pixel 7 Pro (API 36).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/89942804-9755-4ccd-8865-1c1d8343f7d2">|<video src="https://github.com/user-attachments/assets/791cec28-d143-4cd7-9e1b-55772c828860">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
