### PR TITLE
fix: stale layout metrics

### DIFF
--- a/android/src/main/java/com/teleport/portal/PortalView.kt
+++ b/android/src/main/java/com/teleport/portal/PortalView.kt
@@ -275,7 +275,6 @@ class PortalView(
     super.onLayout(changed, left, top, right, bottom)
     layoutStateController.updateIfNeeded(hostName, PortalRegistry.getHost(hostName))
   }
-
   // endregion
 
   // region Accessibility

--- a/android/src/main/java/com/teleport/portal/PortalView.kt
+++ b/android/src/main/java/com/teleport/portal/PortalView.kt
@@ -255,6 +255,11 @@ class PortalView(
   // endregion
 
   // region Lifecycle
+  override fun onAttachedToWindow() {
+    super.onAttachedToWindow()
+    layoutStateController.updateIfNeeded(hostName, PortalRegistry.getHost(hostName))
+  }
+
   override fun onLayout(
     changed: Boolean,
     left: Int,

--- a/android/src/main/java/com/teleport/portal/PortalView.kt
+++ b/android/src/main/java/com/teleport/portal/PortalView.kt
@@ -260,6 +260,11 @@ class PortalView(
     layoutStateController.updateIfNeeded(hostName, PortalRegistry.getHost(hostName))
   }
 
+  override fun onDetachedFromWindow() {
+    layoutStateController.resetIfNeeded()
+    super.onDetachedFromWindow()
+  }
+
   override fun onLayout(
     changed: Boolean,
     left: Int,

--- a/e2e/flows/bottom-sheet.yml
+++ b/e2e/flows/bottom-sheet.yml
@@ -22,8 +22,8 @@ appId: teleport.example
     text: "Sheet"
 - assertNotVisible:
     text: "Close"
-# Maestro does not expose a press/move/release pointer action on web yet;
-# `swipe` scrolls the page instead. The regular tap scenario above still runs.
+# Web is skipped for this scenario because Maestro does not expose a
+# press/move/release pointer API there yet; `swipe` scrolls the page instead.
 # Re-enable when https://github.com/mobile-dev-inc/Maestro/pull/2978 lands.
 - runFlow:
     when:
@@ -37,8 +37,9 @@ appId: teleport.example
           text: "Close"
       - swipe:
           label: "Press, move right, hold, and release Close Bottom Sheet"
-          start: 45%, 55%
-          end: 55%, 55%
+          from:
+            text: "Close"
+          direction: RIGHT
           duration: 3000
       - assertNotVisible:
           text: "Sheet"

--- a/e2e/flows/bottom-sheet.yml
+++ b/e2e/flows/bottom-sheet.yml
@@ -22,3 +22,18 @@ appId: teleport.example
     text: "Sheet"
 - assertNotVisible:
     text: "Close"
+- tapOn:
+    id: "open_bottom_sheet"
+- assertVisible:
+    text: "Sheet"
+- assertVisible:
+    text: "Close"
+- swipe:
+    label: "Press, move right, hold, and release Close Bottom Sheet"
+    start: 45%, 55%
+    end: 55%, 55%
+    duration: 3000
+- assertNotVisible:
+    text: "Sheet"
+- assertNotVisible:
+    text: "Close"

--- a/e2e/flows/bottom-sheet.yml
+++ b/e2e/flows/bottom-sheet.yml
@@ -22,18 +22,25 @@ appId: teleport.example
     text: "Sheet"
 - assertNotVisible:
     text: "Close"
-- tapOn:
-    id: "open_bottom_sheet"
-- assertVisible:
-    text: "Sheet"
-- assertVisible:
-    text: "Close"
-- swipe:
-    label: "Press, move right, hold, and release Close Bottom Sheet"
-    start: 45%, 55%
-    end: 55%, 55%
-    duration: 3000
-- assertNotVisible:
-    text: "Sheet"
-- assertNotVisible:
-    text: "Close"
+# Maestro does not expose a press/move/release pointer action on web yet;
+# `swipe` scrolls the page instead. The regular tap scenario above still runs.
+# Re-enable when https://github.com/mobile-dev-inc/Maestro/pull/2978 lands.
+- runFlow:
+    when:
+      true: ${maestro.platform == 'ios' || maestro.platform == 'android'}
+    commands:
+      - tapOn:
+          id: "open_bottom_sheet"
+      - assertVisible:
+          text: "Sheet"
+      - assertVisible:
+          text: "Close"
+      - swipe:
+          label: "Press, move right, hold, and release Close Bottom Sheet"
+          start: 45%, 55%
+          end: 55%, 55%
+          duration: 3000
+      - assertNotVisible:
+          text: "Sheet"
+      - assertNotVisible:
+          text: "Close"


### PR DESCRIPTION
## 📜 Description

Fixed an issue when "Close" button in `BottomSheet` is not possible to click.

## 💡 Motivation and Context

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

The geometry-reporting mechanism introduced in https://github.com/kirillzyusko/react-native-teleport/issues/148 compensates for the difference between the logical Fabric location of a `PortalView` and the native location where its children are actually rendered.

This offset is required because `Pressability` may call `measure()` after the finger moves. Without the offset, Fabric reports the original shadow-tree position instead of the teleported native position. `Pressability` then considers the finger outside the responder region and cancels `onPress`.

> [!NOTE]
> A simple automated tap can therefore pass while a real press involving slight movement fails.

The offset calculation itself was correct. The problem was when it ran on Android.

Fabric can assign a view’s bounds before that view is attached to a window. Its mounting layer calls `measure()` and `layout()` directly, while `ReactViewGroup` intentionally does not perform a normal recursive Android layout pass. ([Fabric mounting source](https://github.com/react/react-native/blob/v0.81.0/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/fabric/mounting/SurfaceMountingManager.java#L778-L847), [ReactViewGroup source](https://github.com/react/react-native/blob/v0.81.0/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt#L226-L240))

In the failing sequence:

1. Fabric laid out `PortalView` while it was still detached.
2. `onLayout()` called `updateIfNeeded()`.
3. `updateIfNeeded()` rejected the calculation because either the source or host was not attached. This is intentional: the offset uses `getLocationOnScreen()`, which requires both views to have a valid window coordinate space.
4. The view was attached later, but its local bounds had not changed and Fabric did not send another layout mutation.
5. Consequently, `onLayout()` was not called again and Fabric retained empty or stale portal geometry.

Window attachment and layout are separate lifecycle events on Android: `onLayout()` describes local size and position, whereas `onAttachedToWindow()` signals that the view now belongs to a window and has meaningful screen coordinates. [Android View documentation](https://developer.android.com/reference/android/view/View), [ViewGroup documentation](https://developer.android.com/reference/android/view/ViewGroup)

Calling `updateIfNeeded()` from `onAttachedToWindow()` is therefore not applying an additional layout correction. It reruns the same idempotent calculation at the first lifecycle point where its window-relative inputs are valid. If `onLayout()` already published the correct values, `publishIfChanged()` prevents a redundant Fabric state update.

The inverse is handled in `onDetachedFromWindow()`. Once the source view leaves the window, its previously reported screen-space offset is no longer valid. Resetting it prevents stale geometry from surviving navigation, native-screen detachment, or view recycling. The next attachment recalculates the offset from the current native hierarchy.

iOS did not reproduce the issue because, in this flow, UIKit invoked `layoutSubviews` after the relevant views had acquired a window. Android’s Fabric mounting and attachment order did not provide an equivalent post-attachment layout callback, so the explicit attachment lifecycle update is required.

Restore code that was originally removed in https://github.com/kirillzyusko/react-native-teleport/pull/150/changes/cb1e9754055ad4ccfcee78a4265ef23fbbec5124

## 📢 Changelog

<!-- High level overview of important changes -->
<!-- For example: fixed status bar manipulation; added new types declarations; -->
<!-- If your changes don't affect one of platform/language below - then remove this platform/language -->

### Android

- update layout metrics from `onAttachedToWindow`;
- reset layout metrics in `onDetachedFromWindow`;

### E2E

- cover regression with extended e2e test;

## 🤔 How Has This Been Tested?

Tested manually on Pixel 7 Pro (API 36).

## 📸 Screenshots (if appropriate):

|Before|After|
|-------|-----|
|<video src="https://github.com/user-attachments/assets/fcca2737-4fdc-41f4-8e60-2c6a81ff311a">|<video src="https://github.com/user-attachments/assets/a8722645-df62-4600-ad4d-dda8ccb57f9e">|

## 📝 Checklist

- [x] CI successfully passed
- [x] I added new mocks and corresponding unit-tests if library API was changed
